### PR TITLE
fix the desktop file

### DIFF
--- a/data/budgie-desktop.desktop.in
+++ b/data/budgie-desktop.desktop.in
@@ -5,4 +5,3 @@ Exec=@prefix@/bin/budgie-session
 TryExec=@prefix@/bin/budgie-session
 Icon=
 Type=Application
-Name[en_US]=budgie-desktop.desktop


### PR DESCRIPTION
This line caused the budgie session to be displayed as `budgie-desktop.desktop` instead of `Budgie Desktop` on my login screen.
