### PR TITLE
remove the margin from the tasklist applet

### DIFF
--- a/panel/applets/tasklist/TaskListApplet.vala
+++ b/panel/applets/tasklist/TaskListApplet.vala
@@ -32,9 +32,6 @@ public class TaskListAppletImpl : Budgie.Applet
         orientation_changed.connect((o) => {
             widget.set_orientation(o);
         });
-
-        margin_top = 2;
-        margin_bottom = 2;
     }
 } // End class
 


### PR DESCRIPTION
The margin breaks GNOME theme compatibility (e.g. the Ubuntu Ambiance theme).
