### PR TITLE
RunDialog: skip taskbar and pager hint

### DIFF
--- a/rundialog/RunDialog.vala
+++ b/rundialog/RunDialog.vala
@@ -36,6 +36,8 @@ public class RunDialog : Gtk.Window
         window_position = Gtk.WindowPosition.CENTER;
         destroy.connect(() => Gtk.main_quit());
         set_keep_above(true);
+        set_skip_taskbar_hint(true);
+        set_skip_pager_hint(true);
         title = "Run Program...";
         icon_name = DEFAULT_ICON;
 


### PR DESCRIPTION
I noticed that the RunDialog appears in the panel. I'm not sure if this is intentional, but I thought it's cleaner to skip the taskbar (and also the pager) hint. As you can see it didn't take long to implement, so feel free to disregard it if I fixed a non-issue :p

Cheers!
