### PR TITLE
panel: applet workspaces - more focus on active workspace - closes #126

### DIFF
--- a/data/app.css
+++ b/data/app.css
@@ -85,3 +85,8 @@ PanelToplevel GtkEventBox {
     background-image: none;
     background-color: transparent;
 }
+
+/* active workspace */
+WnckPager:selected {
+    background: rgba(0, 0, 0, 0.25),;
+}


### PR DESCRIPTION
Hi,

Add a darker background on the active workspace

Here a preview:

![t](https://cloud.githubusercontent.com/assets/1774748/5332636/0da0e96e-7e5e-11e4-9c0b-73e75f46aa6e.png)
