### PR TITLE
budgie-plugin: Use $(libdir) for pkgconfigdir

### DIFF
--- a/budgie-plugin/Makefile.am
+++ b/budgie-plugin/Makefile.am
@@ -61,7 +61,7 @@ EXTRA_DIST += \
 	budgie-1.0.pc.in
 
 pkgconfigdir = \
-	$(prefix)/lib/pkgconfig
+	$(libdir)/pkgconfig
 
 pkgconfig_DATA = \
 	budgie-1.0.pc


### PR DESCRIPTION
This fixes installation if /usr/lib isn't the right directory for libraries, which is normally the case on multiarch systems; for example an x86_64 system that can run i386 apps would have /usr/lib32 and /usr/lib64.
