### PR TITLE
Window grouping

### DIFF
--- a/panel/applets/icon-tasklist/Application.vala
+++ b/panel/applets/icon-tasklist/Application.vala
@@ -1,0 +1,338 @@
+/*
+ * This file is part of budgie-desktop
+ *
+ * Copyright (C) 2016 Fernando Mussel <fernandomussel91@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+public class Application: AttentionStatusListener, IconChangeListener, ScreenProvider
+{
+
+    private HashTable<unowned Wnck.Window, ApplicationWindow>? appwindow_map = null;
+    // atm, this is the most recently opened window of this application
+    private ApplicationWindow? active_appwin = null;
+
+    private WindowListView? window_list = null;
+    private IconButton button;
+    private unowned WindowManager window_manager;
+    private unowned ApplicationManager app_manager;
+    private uint windows_requiring_attention_num = 0;
+    private GLib.DesktopAppInfo? app_info = null;
+    private unowned Settings settings;
+    private string? wclass_name = null;
+    ulong wclass_id = 0;
+
+
+    public Application(IconButton btn, WindowManager window_manager,
+                       DesktopAppInfo? app_info, Settings settings,
+                       ApplicationManager app_manager)
+    {
+
+        appwindow_map = new HashTable<unowned Wnck.Window, ApplicationWindow>(direct_hash, direct_equal);
+        button = btn;
+        this.app_info = app_info;
+        this.settings = settings;
+        this.app_manager = app_manager;
+        button.set_application(this);
+
+        this.window_manager = window_manager;
+        window_list = new WindowListView(button, window_manager);
+        button.reset();
+    }
+
+    public void add_window(Wnck.Window window)
+    {
+        // create the menu for the new window
+        WindowMenu menu = new WindowMenu(window, app_info, settings, this, this);
+        ApplicationWindow appwin = new ApplicationWindow(window, menu);
+
+        appwindow_map [window] = appwin;
+        window_list.add_window(appwin);
+        set_active_window(window);
+
+        // Setup event listeners
+        appwin.set_attention_status_listener(this);
+        appwin.set_icon_change_listener(this);
+        // configures the window minimization animation
+        update_window_minimize_animation(window);
+
+        if (get_window_num() == 1) {
+            // this is the first window of this application. Configure the
+            // button (icon, menu, etc) based on this window's info
+            button.configure_button(appwin);
+            configure_application(appwin);
+        }
+    }
+
+    public void remove_window(Wnck.Window window)
+    {
+        // make sure we have this window
+        assert_window_exists(window);
+        ApplicationWindow appwin = appwindow_map [window];
+
+        // remove it from the window list popover
+        window_list.remove_window(appwin);
+        appwindow_map.remove(window);
+
+        if (appwin.needs_attention()) {
+            // the window was asking for attention but we closed it. Register
+            // end of attetion request
+            attention_requested_ended();
+        }
+
+        if (get_window_num() == 0) {
+            // the application has no more windows opened. Reset the associated
+            // button. This is specially important for Pinned Applications
+            button.reset();
+            active_appwin = null;
+        } else if (appwin == active_appwin) {
+            // We are removing the "active window". Change the active_appwin
+            // to the second most recently opened window
+            active_appwin = null;
+            set_active_window(get_first_window());
+        }
+    }
+
+    public void close_all_windows()
+    {
+        // get the list of opened windows
+        var appwin_keys = appwindow_map.get_keys();
+
+        // ask the window manager to close each one of them
+        appwin_keys.foreach((window)=> {
+            window_manager.close_window(window);
+        });
+    }
+
+    /**
+     * Replace the button associated with application for a new one.
+     */
+    public void replace_button(IconButton btn)
+    {
+        button = btn;
+        // give a reference to ourselves to the new button
+        button.set_application(this);
+        // make the new button the owner of the window list popover
+        window_list.replace_owner(button);
+
+        if (get_window_num() > 0) {
+            // we have at least one window. So configure the new button according
+            // to one of our opened windows
+            button.configure_button(active_appwin);
+        }
+    }
+
+    public uint get_window_num()
+    {
+        return appwindow_map.size();
+    }
+
+    public bool has_window_opened()
+    {
+        return get_window_num() > 0;
+    }
+
+    public Gtk.Popover get_window_list_popover()
+    {
+        return window_list.get_popover();
+    }
+
+    public string? get_id()
+    {
+        return (app_info == null) ? null : app_info.get_id();
+    }
+
+    public GLib.DesktopAppInfo? get_info()
+    {
+        return app_info;
+    }
+
+    /**
+     * Returns a reference to the most recently opened window or null if there
+     * is no window opened
+     */
+    public Wnck.Window? get_active_window()
+    {
+        Wnck.Window? window = null;
+        if (active_appwin != null) {
+            window = active_appwin.get_window();
+        }
+        return window;
+    }
+
+    public void set_active_window(Wnck.Window window)
+    {
+        var new_active_appwin = appwindow_map [window];
+        // prevent unnecessary work if the new active window is the same as before
+        if (new_active_appwin != active_appwin) {
+            active_appwin = new_active_appwin;
+            button.update_icon(window);
+        }
+    }
+
+    public void show_active_window_menu(uint event_button, uint32 timestamp)
+    {
+        if (active_appwin != null) {
+            var menu = active_appwin.get_menu();
+
+            if (app_info == null) {
+                // we can not pin or unpin an application that we do not have
+                // DesktopAppInfo about
+                menu.disable_all_pinning_options();
+            } else if (button is PinnedIconButton) {
+                // Application is already pinned. Enable the unpinning option
+                menu.enable_unpinning_option();
+            } else {
+                menu.enable_pinning_option();
+            }
+            menu.show(event_button, timestamp);
+        }
+    }
+
+
+    public IconButton get_button()
+    {
+        return button;
+    }
+
+    /**
+     * Get any window from the HashTable
+     */
+    private Wnck.Window? get_first_window()
+    {
+        var iter = HashTableIter<unowned Wnck.Window, ApplicationWindow>(appwindow_map);
+        Wnck.Window? win = null;
+
+        iter.next(out win, null);
+        return win;
+    }
+
+    /**
+     * Configures the window's minimize animation based on the application's
+     * button position in the tasklist
+     */
+    private void update_window_minimize_animation(Wnck.Window window)
+    {
+        int x, y;
+        button.get_coordinates(out x, out y);
+        var alloc = button.get_allocation();
+
+        window.set_icon_geometry(x, y, alloc.width, alloc.height);
+    }
+
+    /**
+     * When the application's button changes place this function is called
+     * to update the minimize animation of all windows registered
+     */
+    public void button_allocation_updated()
+    {
+        var iter = HashTableIter<Wnck.Window, ApplicationWindow>(appwindow_map);
+        Wnck.Window? window = null;
+
+        // Updates the minimize animation of all the windows
+        while (iter.next(out window, null)) {
+            update_window_minimize_animation(window);
+        }
+    }
+
+    /**
+     * This function is part of the AttentionStatusListener interface. It is
+     * called by ApplicationWindow when a Window begins or ends an attention
+     * request
+     */
+    public void attention_status_changed(ApplicationWindow appwin, bool needs_attention)
+    {
+        if (needs_attention) {
+            // update the # of windows requesting attention
+            ++windows_requiring_attention_num;
+            // forward change to application button
+            button.begin_attention_request();
+            // forward change to window list item associated with the requesting
+            // window
+            window_list.begin_attention_request(appwin);
+        } else {
+            window_list.end_attention_request(appwin);
+            attention_requested_ended();
+        }
+    }
+
+    /**
+     * Function is part of the ScreenProvider interface. By making the application
+     * object the provider, we do not need to update the provider reference
+     * in all window menus when the button changes, e.g. during pinning and
+     * unpinning
+     */
+    public Gdk.Screen get_screen()
+    {
+        return button.get_screen();
+    }
+
+    /**
+     * Function is part of the IconChangeListener interface. Update the button's
+     * icon if the window whose icon changed is the "active" one
+     */
+    public void icon_changed(ApplicationWindow appwin)
+    {
+        if (appwin == active_appwin) {
+            button.update_icon(appwin.get_window());
+        }
+    }
+
+    private void attention_requested_ended()
+    {
+        --windows_requiring_attention_num;
+        // Only forward to button the end of the attention request if no more
+        // windows are requesting it
+        if (windows_requiring_attention_num == 0) {
+            button.end_attention_request();
+        }
+    }
+
+    private void assert_window_exists(Wnck.Window window)
+    {
+        assert(appwindow_map.contains(window));
+    }
+
+    /**
+     * Performs general application-wide configurations that are only possible
+     * after the first window is registered
+     */
+    private void configure_application(ApplicationWindow first_app_win)
+    {
+        var window = first_app_win.get_window();
+        wclass_name = window.get_class_instance_name();
+
+        /* No app info, no class name, probably spotify */
+        if (app_info == null && wclass_name == null) {
+            // setup callback for window class change
+            wclass_id = window.class_changed.connect((win)=> {
+                string nclass_name = win.get_class_instance_name();
+                if (nclass_name != null && wclass_name == null) {
+                    // unregister callback
+                    win.disconnect(wclass_id);
+                    wclass_id = 0;
+                    // update window app info
+                    wclass_name = nclass_name;
+                    app_info = window_manager.query_window(win);
+
+                    if (app_info != null && app_manager.app_info_update(win, app_info)) {
+                        // we have managed to get info on the application (Spotify) and
+                        // the application manager returned true for app_info_update
+                        // call, meaning that it will continue to use this application
+                        // object instance. So we need to do some housekeeping and
+                        // re-configure things based on app_info
+                        WindowMenu menu = new WindowMenu(win, app_info, settings, this, this);
+                        appwindow_map [win].set_menu(menu);
+                        // reconfigure button now using app_info
+                        button.configure_button(appwindow_map [win]);
+                    }
+                }
+            });
+        }
+    }
+
+}

--- a/panel/applets/icon-tasklist/ApplicationWindow.vala
+++ b/panel/applets/icon-tasklist/ApplicationWindow.vala
@@ -1,0 +1,119 @@
+/*
+ * This file is part of budgie-desktop
+ *
+ * Copyright (C) 2016 Fernando Mussel <fernandomussel91@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+public class ApplicationWindow
+{
+    private Wnck.Window? window = null;
+    private unowned NameChangeListener? name_listener;
+    private unowned IconChangeListener? icon_listener;
+    private unowned AttentionStatusListener? attention_status_listener;
+
+    private ulong icon_changed_id = 0;
+    private ulong name_changed_id = 0;
+    private ulong state_changed_id = 0;
+
+    private bool attention_requested = false;
+    private WindowMenu? menu = null;
+
+    public ApplicationWindow(Wnck.Window window,
+                             WindowMenu menu)
+    {
+
+        this.window = window;
+        this.name_listener = null;
+        this.icon_listener = null;
+        this.attention_status_listener = null;
+        this.menu = menu;
+
+        // setup callbacks to all the window events we are interested in
+        name_changed_id = this.window.name_changed.connect(update_name);
+        icon_changed_id = this.window.icon_changed.connect(update_icon);
+        state_changed_id = this.window.state_changed.connect(state_changed);
+    }
+
+    ~ApplicationWindow()
+    {
+        this.window.disconnect(icon_changed_id);
+        this.window.disconnect(name_changed_id);
+        this.window.disconnect(state_changed_id);
+        // We must call this to free the WindowMenu instance
+        this.menu.clear();
+    }
+
+    private void update_icon()
+    {
+        if (icon_listener != null) {
+            icon_listener.icon_changed(this);
+        }
+    }
+
+    private void update_name()
+    {
+        if (name_listener != null) {
+            name_listener.name_changed(this, window.get_name());
+        }
+    }
+
+    private void state_changed(Wnck.WindowState changed, Wnck.WindowState state)
+    {
+        if (window.needs_attention() && !attention_requested) {
+            // window has just requested attention
+            attention_requested = true;
+        } else if (!window.needs_attention() && attention_requested) {
+            attention_requested = false;
+        } else {
+            // no change
+            return;
+        }
+
+        // If we reached here, the attention status changed. Send signal if
+        // there is a listener
+        if (attention_status_listener != null) {
+            attention_status_listener.attention_status_changed(this, attention_requested);
+        }
+    }
+
+    public unowned Wnck.Window get_window()
+    {
+        return window;
+    }
+
+    public void set_name_change_listener(NameChangeListener listener)
+    {
+        name_listener = listener;
+    }
+
+    public void set_icon_change_listener(IconChangeListener listener)
+    {
+        icon_listener = listener;
+    }
+
+    public void set_attention_status_listener(AttentionStatusListener listener)
+    {
+        attention_status_listener = listener;
+    }
+
+    public bool needs_attention()
+    {
+        return attention_requested;
+    }
+
+    public WindowMenu get_menu()
+    {
+        return menu;
+    }
+
+    public void set_menu(WindowMenu menu)
+    {
+        this.menu.clear();
+        this.menu = menu;
+    }
+}

--- a/panel/applets/icon-tasklist/ApplicationWindowListeners.vala
+++ b/panel/applets/icon-tasklist/ApplicationWindowListeners.vala
@@ -1,0 +1,26 @@
+/*
+ * This file is part of budgie-desktop
+ *
+ * Copyright (C) 2016 Fernando Mussel <fernandomussel91@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+public interface NameChangeListener
+{
+    public abstract void name_changed(ApplicationWindow appwin, string new_name);
+}
+
+public interface IconChangeListener
+{
+    public abstract void icon_changed(ApplicationWindow appwin);
+}
+
+public interface AttentionStatusListener
+{
+    public abstract void attention_status_changed(ApplicationWindow appwin,
+                                                  bool needs_attention );
+}

--- a/panel/applets/icon-tasklist/ButtonManager.vala
+++ b/panel/applets/icon-tasklist/ButtonManager.vala
@@ -1,0 +1,15 @@
+/*
+ * This file is part of budgie-desktop
+ *
+ * Copyright (C) 2016 Fernando Mussel <fernandomussel91@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+public interface ButtonManager
+{
+    public abstract bool can_become_active(IconButton btn);
+}

--- a/panel/applets/icon-tasklist/Buttons.vala
+++ b/panel/applets/icon-tasklist/Buttons.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright (C) 2014-2016 Ikey Doherty <ikey@solus-project.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -10,18 +10,6 @@
  */
 
 const string BUDGIE_STYLE_CLASS_BUTTON = "launcher";
-
-/**
- * Maximum number of full flash cycles for urgency before giving up. Note
- * that the background colour will remain fully opaque until the calling
- * application then resets whatever caused the urgency/attention demand
- */
-const int MAX_CYCLES = 12;
-
-/**
- * Default opacity when beginning urgency cycles in the launcher
- */
-const double DEFAULT_OPACITY = 0.1;
 
 public class ButtonWrapper : Gtk.Revealer
 {
@@ -56,208 +44,36 @@ public class ButtonWrapper : Gtk.Revealer
 public class IconButton : Gtk.ToggleButton
 {
 
+
+    private unowned AppSystem? helper = null;
+    protected unowned ButtonManager? btn_manager_ = null;
+    protected unowned WindowManager? window_manager = null;
+    protected weak Application? application = null;
+
     public new Gtk.Image image;
-    public unowned Wnck.Window? window;
-    protected Wnck.ActionMenu menu;
+
     public int icon_size;
-    public GLib.DesktopAppInfo? ainfo;
-    private Gtk.MenuItem pinnage;
-    private Gtk.MenuItem unpinnage;
-    private Gtk.SeparatorMenuItem sep_item;
 
-    public bool requested_pin = false;
-
-    private bool we_urgent = false;
-    private double urg_opacity = DEFAULT_OPACITY;
-    protected bool should_fade_in = true;
-    private uint source_id;
     protected Gtk.Allocation our_alloc;
-
-    protected int current_cycles = 0;
+    protected bool is_allocated = false;
+    private UrgencyAnimation urgency_animation;
+    // last absolute coordinates assigned to this button
+    private int last_absx = -1;
+    private int last_absy = -1;
 
     unowned Settings? settings;
 
     public int panel_size = 10;
+    private ulong size_allocate_cb = 0;
+    private ulong btn_release_cb = 0;
+    private ulong btn_toggle_cb = 0;
 
-    private void update_app_info()
-    {
-        // Actions menu
-        menu = new Wnck.ActionMenu(window);
-
-        var sep = new Gtk.SeparatorMenuItem();
-        menu.append(sep);
-        sep_item = sep;
-        pinnage = new Gtk.MenuItem.with_label(_("Pin to panel"));
-        unpinnage = new Gtk.MenuItem.with_label(_("Unpin from panel"));
-        sep.show();
-        menu.append(pinnage);
-        menu.append(unpinnage);
-
-        /* Handle running instance pin/unpin */
-        pinnage.activate.connect(()=> {
-            requested_pin = true;
-            DesktopHelper.set_pinned(settings, ainfo, true);
-        });
-
-        unpinnage.activate.connect(()=> {
-            if (this is /*Sparta*/ PinnedIconButton) {
-                var p = this as PinnedIconButton;
-                DesktopHelper.set_pinned(settings, p.app_info, false);
-            }
-        });
-
-        if (ainfo != null) {
-            // Desktop app actions =)
-            unowned string[] actions = ainfo.list_actions();
-            if (actions.length == 0) {
-                return;
-            }
-            sep = new Gtk.SeparatorMenuItem();
-            menu.append(sep);
-            sep.show_all();
-            foreach (var action in actions) {
-                var display_name = ainfo.get_action_name(action);
-                var item = new Gtk.MenuItem.with_label(display_name);
-                item.set_data("__aname", action);
-                item.activate.connect(()=> {
-                    string? act = item.get_data("__aname");
-                    if (act == null) {
-                        return;
-                    }
-                    // Never know.
-                    if (ainfo == null) {
-                        return;
-                    }
-                    var launch_context = Gdk.Screen.get_default().get_display().get_app_launch_context();
-                    launch_context.set_screen(get_screen());
-                    launch_context.set_timestamp(Gdk.CURRENT_TIME);
-                    ainfo.launch_action(act, launch_context);
-                });
-                item.show_all();
-                menu.append(item);
-            }
-        }
-        this.update_icon();
-    }
-
-    public void update_from_window()
-    {
-        we_urgent = false;
-        if (source_id > 0) {
-            remove_tick_callback(source_id);
-            source_id = 0;
-        }
-
-        if (window == null) {
-            if (this is PinnedIconButton) {
-                this.get_style_context().remove_class("running");
-            }
-            return;
-        }
-
-        if (this is PinnedIconButton) {
-            this.get_style_context().add_class("running");
-        }
-        set_tooltip_text(window.get_name());
-
-        // Things we can happily handle ourselves
-        window.icon_changed.connect(update_icon);
-        window.name_changed.connect(()=> {
-            set_tooltip_text(window.get_name());
-        });
-        update_icon();
-        set_active(window.is_active());
-        window.state_changed.connect(on_state_changed);
-
-        this.update_app_info();
-        queue_draw();
-    }
-
-    protected void on_state_changed(Wnck.WindowState changed, Wnck.WindowState state)
-    {
-        if (!window.needs_attention() && we_urgent) {
-            we_urgent = false;
-            if (source_id > 0) {
-                remove_tick_callback(source_id);
-                source_id = 0;
-            }
-            queue_draw();
-            return;
-        } else if (window.needs_attention() && !we_urgent) {
-            we_urgent = true;
-            should_fade_in = true;
-            urg_opacity = DEFAULT_OPACITY;
-            current_cycles = 0;
-            source_id = add_tick_callback(on_tick);
-        }
-    }
-
-    protected bool on_tick(Gtk.Widget widget, Gdk.FrameClock clock)
-    {
-        // Looks fine with 60hz. Might go nuts higher.
-        var increment = 0.01;
-
-        if (window == null) {
-            urg_opacity = 0.0;
-            we_urgent = false;
-            return false;
-        }
-
-        if (should_fade_in) {
-            urg_opacity += increment;
-        } else {
-            urg_opacity -= increment;
-        }
-
-        if (urg_opacity >= 1.0) {
-            should_fade_in = false;
-            urg_opacity = 1.0;
-            current_cycles += 1;
-        } else if (urg_opacity <= 0.0) {
-            should_fade_in = true;
-            urg_opacity = 0.0;
-        }
-
-        queue_draw();
-
-        /* Stop flashing when we've fully cycled MAX_CYCLES */
-        if (current_cycles >= MAX_CYCLES && urg_opacity >= 1.0) {
-            return false;
-        }
-
-        return we_urgent;
-    }
-
-    public override bool draw(Cairo.Context cr)
-    {
-        if (!we_urgent) {
-            return base.draw(cr);
-        }
-
-        /* Redundant right now but we might decide on something new in future. */
-        int x = our_alloc.x;
-        int y = our_alloc.y;
-        int width = our_alloc.width;
-        int height = our_alloc.height;
-
-        Gdk.RGBA col = {};
-        /* FIXME: I'M ON DRUGS */
-        col.parse("#36689E");
-        cr.set_source_rgba(col.red, col.green, col.blue, urg_opacity);
-        cr.rectangle(x, y, width, height);
-        cr.paint();
-
-        return base.draw(cr);
-    }
-
-    private string wclass_name = null;
-    private ulong wclass_id = 0;
-    private unowned AppSystem? helper = null;
-
-    public IconButton(Settings? settings, Wnck.Window? window, int size, DesktopAppInfo? ainfo, AppSystem? helper, int panel_size)
+    public IconButton(Settings? settings, int size, AppSystem? helper, int panel_size, ButtonManager btn_manager, WindowManager? window_manager)
     {
         this.settings = settings;
         this.helper = helper;
+        this.btn_manager_ = btn_manager;
+        this.window_manager = window_manager;
 
         image = new Gtk.Image();
         image.pixel_size = size;
@@ -265,43 +81,68 @@ public class IconButton : Gtk.ToggleButton
         this.panel_size = panel_size;
         add(image);
 
-        this.window = window;
         relief = Gtk.ReliefStyle.NONE;
-        this.ainfo = ainfo;
+        urgency_animation = new UrgencyAnimation(this);
 
-        if (this.window != null) {
-            this.wclass_name = this.window.get_class_instance_name();
-        }
-
-        /* No app info, no class name, probably spotify */
-        if (this.wclass_name == null && this.ainfo == null) {
-            this.wclass_id = this.window.class_changed.connect(()=> {
-                string nclass_name = this.window.get_class_instance_name();
-                if (nclass_name != null && this.wclass_name == null) {
-                    this.window.disconnect(this.wclass_id);
-                    this.wclass_id = 0;
-
-                    this.wclass_name = nclass_name;
-                    this.ainfo = helper.query_window(this.window);
-                    this.update_app_info();
-                    /* Request re-assess of pin move ? */
-                }
-            });
-        }
-            
 
         // Replace styling with our own
         var st = get_style_context();
         st.remove_class(Gtk.STYLE_CLASS_BUTTON);
         st.add_class(BUDGIE_STYLE_CLASS_BUTTON);
-        size_allocate.connect(on_size_allocate);
+        size_allocate_cb = size_allocate.connect(on_size_allocate);
 
-        update_from_window();
 
         // Handle clicking, etc.
-        button_release_event.connect(on_button_release);
-
+        btn_release_cb = button_release_event.connect(on_button_release);
+        btn_toggle_cb = this.toggled.connect_after(on_toggle);
         set_can_focus(false);
+    }
+
+    public void set_button_as_running()
+    {
+        this.get_style_context().add_class("running");
+    }
+
+    public void set_button_as_not_running()
+    {
+        this.get_style_context().remove_class("running");
+        set_active(false);
+    }
+
+    /**
+     * This function should be called when the first application window is opened
+     * to perform the initial configuration of the button.
+     */
+    public virtual void configure_button(ApplicationWindow appwin)
+    {
+        Wnck.Window window = appwin.get_window();
+
+        // mark button as running
+        set_button_as_running();
+        // setup application icon
+        update_icon(window);
+    }
+
+    public void begin_attention_request()
+    {
+        // one of the windows requested attention
+        urgency_animation.begin_animation();
+    }
+
+    public void end_attention_request()
+    {
+        // no window is requesting attention anymore
+        urgency_animation.end_animation();
+    }
+
+    public void on_toggle()
+    {
+        if (get_active()) {
+            // Only become active if we have permission to do so
+            if (!btn_manager_.can_become_active(this)) {
+                set_active(false);
+            }
+        }
     }
 
     /**
@@ -315,59 +156,70 @@ public class IconButton : Gtk.ToggleButton
         nat = norm;
     }
 
-
-    /**
-     * After allocation to ensure we go to the right place
-     */
-    public void icon_mapped()
+    public Wnck.Window? get_active_window()
     {
-        if (window == null) {
-            return;
-        }
-        int x, y;
-        var toplevel = get_toplevel();
-        translate_coordinates(toplevel, 0, 0, out x, out y);
-        toplevel.get_window().get_root_coords(x, y, out x, out y);
-        window.set_icon_geometry(x, y, our_alloc.width, our_alloc.height);
+        return application.get_active_window();
+    }
+
+    public Gtk.Allocation get_allocation()
+    {
+        return our_alloc;
     }
 
     /**
-     * This is for minimize animations, etc.
+     * Return the absolute coordinates of this button
      */
-    protected void on_size_allocate(Gtk.Allocation alloc)
+    public void get_coordinates(out int x, out int y)
     {
-        if (window == null) {
+        if (!is_allocated) {
+            // button has not been allocated yet. Return (0,0) coordinate
+            x = 0;
+            y = 0;
             return;
         }
-        int x, y;
         var toplevel = get_toplevel();
         translate_coordinates(toplevel, 0, 0, out x, out y);
         toplevel.get_window().get_root_coords(x, y, out x, out y);
-        window.set_icon_geometry(x, y, alloc.width, alloc.height);
+    }
 
+    /**
+     * Button's size allocation changed.
+     */
+    protected void on_size_allocate(Gtk.Allocation alloc)
+    {
+        is_allocated = true;
         our_alloc = alloc;
+
+        int new_absx, new_absy;
+        get_coordinates(out new_absx, out new_absy);
+        // check if the button has changed position
+        if (new_absx != last_absx || new_absy != last_absy) {
+            last_absx = new_absx;
+            last_absy = new_absy;
+
+            // forward the allocation change to the application object
+            application.button_allocation_updated();
+        }
     }
 
     /**
      * Update the icon
      */
-    public virtual void update_icon()
+    public virtual void update_icon(Wnck.Window? window)
     {
-        if (window == null) {
-            return;
-        }
+        assert(window != null);
 
         unowned GLib.Icon? aicon = null;
-        if (ainfo != null) {
-            aicon = ainfo.get_icon();
+        if (application.get_info() != null) {
+            aicon = application.get_info().get_icon();
         }
 
         if (this.helper.has_derpy_icon(window) && aicon != null) {
             image.set_from_gicon(aicon, Gtk.IconSize.INVALID);
         } else {
             if (window.get_icon_is_fallback()) {
-                if (ainfo != null && ainfo.get_icon() != null) {
-                    image.set_from_gicon(ainfo.get_icon(), Gtk.IconSize.INVALID);
+                if (application.get_info() != null && application.get_info().get_icon() != null) {
+                    image.set_from_gicon(application.get_info().get_icon(), Gtk.IconSize.INVALID);
                 } else {
                     image.set_from_pixbuf(window.get_icon());
                 }
@@ -376,111 +228,140 @@ public class IconButton : Gtk.ToggleButton
             }
         }
         image.pixel_size = icon_size;
+        // invalidates button for redraw
+        queue_resize();
+    }
+
+    public virtual void update_icon_size(int new_size)
+    {
+        icon_size = new_size;
+        image.pixel_size = icon_size;
         queue_resize();
     }
 
     /**
-     * Either show the actions menu, or activate our window
+     * Either show the actions menu, toogle our window or show the window list
+     * if there are more than 1 application windows opened
      */
     public virtual bool on_button_release(Gdk.EventButton event)
     {
-        var timestamp = Gtk.get_current_event_time();
-
-        if (window != null) {
-            if (this is /*Sparta*/ PinnedIconButton) {
-                unpinnage.show();
-                pinnage.hide();
-            } else {
-                unpinnage.hide();
-                pinnage.show();
-            }
-        }
-
-        if (ainfo == null) {
-            unpinnage.hide();
-            pinnage.hide();
-            sep_item.hide();
-        } else {
-            if (sep_item != null) {
-                sep_item.show();
-            }
-        }
-
         // Right click, i.e. actions menu
         if (event.button == 3) {
-            menu.popup(null, null, null, event.button, timestamp);
+            var timestamp = Gtk.get_current_event_time();
+            application.show_active_window_menu(event.button, timestamp);
             return true;
         }
-        if (window == null) {
-            return base.button_release_event(event);
-        }
 
-        // Normal left click, go handle the window
-        if (window.is_minimized()) {
-            window.unminimize(timestamp);
-            window.activate(timestamp);
+        if (!application.has_window_opened()) {
+            // no window. Do nothing
+            return base.button_release_event(event);
         } else {
-            if (window.is_active()) {
-                window.minimize();
+            var active_window = application.get_active_window();
+            if (application.get_window_num() == 1) {
+                // only one window. Toggle it
+                window_manager.toggle_window(active_window);
+            } else if (active_window.is_active()) {
+                // multiple windows and the active one is showing. Toggle
+                // window list
+                window_manager.toggle_window_list(this, application.get_window_list_popover());
             } else {
-                window.activate(timestamp);
+                // multiple windows but the app's active one is not showing.
+                // Toggle it
+                window_manager.toggle_window(active_window);
             }
         }
 
         return base.button_release_event(event);
     }
-            
+
+    public virtual void set_application(Application app)
+    {
+        application = app;
+    }
+
+    public virtual void reset()
+    {
+        set_button_as_not_running();
+    }
+
+    public void reset_callbacks()
+    {
+        disconnect (size_allocate_cb);
+        disconnect (btn_release_cb);
+        disconnect (btn_toggle_cb);
+        // just in case
+        urgency_animation.end_animation();
+    }
+
 }
 
 public class PinnedIconButton : IconButton
 {
-    public DesktopAppInfo app_info;
     protected unowned Gdk.AppLaunchContext? context;
     public string? id = null;
     private Gtk.Menu alt_menu;
+    private Gtk.MenuItem unpin_item;
 
     unowned Settings? settings;
 
-    public PinnedIconButton(Settings settings, DesktopAppInfo info, int size, ref Gdk.AppLaunchContext context, AppSystem? helper, int panel_size)
+    public PinnedIconButton(Settings settings, int size, ref Gdk.AppLaunchContext context, AppSystem? helper, int panel_size, ButtonManager btn_manager, WindowManager window_manager)
     {
-        base(settings, null, size, info, helper, panel_size);
-        this.app_info = info;
+        base(settings, size, helper, panel_size, btn_manager, window_manager);
         this.settings = settings;
-
         this.context = context;
-        set_tooltip_text("Launch %s".printf(info.get_display_name()));
-        image.set_from_gicon(info.get_icon(), Gtk.IconSize.INVALID);
 
+        // Configure Unpin menu
         alt_menu = new Gtk.Menu();
-        var item = new Gtk.MenuItem.with_label("Unpin from panel");
-        alt_menu.add(item);
-        item.show_all();
+        unpin_item = new Gtk.MenuItem.with_label(_("Unpin from panel"));
+        alt_menu.add(unpin_item);
+        unpin_item.show_all();
 
-        item.activate.connect(()=> {
-            DesktopHelper.set_pinned(settings, this.app_info, false);
-        });
         set_can_focus(false);
-        
+
         // Drag and drop
         Gtk.drag_source_set(this, Gdk.ModifierType.BUTTON1_MASK, DesktopHelper.targets, Gdk.DragAction.MOVE);
-        
+
         drag_begin.connect((context)=> {
-            if(ainfo != null) {
-                Gtk.drag_set_icon_gicon(context, this.app_info.get_icon(), 0, 0);
+            // hide window list popover if its visible
+            var popover = application.get_window_list_popover();
+            if (popover.get_visible()) {
+                popover.hide();
+            }
+
+            if(application.get_info() != null) {
+                Gtk.drag_set_icon_gicon(context, application.get_info().get_icon(), 0, 0);
             } else {
                 Gtk.drag_set_icon_default(context);
             }
         });
 
         drag_data_get.connect((widget, context, selection_data, info, time)=> {
-            selection_data.set(selection_data.get_target(), 8, (uchar []) this.app_info.get_id().to_utf8());
+            selection_data.set(selection_data.get_target(), 8, (uchar []) application.get_info().get_id().to_utf8());
+        });
+    }
+
+    ~PinnedIconButton()
+    {
+        alt_menu.destroy();
+    }
+
+    public override void set_application(Application app)
+    {
+        base.set_application(app);
+
+        reset_icon();
+        // Configure the unpin action using the application's app_info
+        unpin_item.activate.connect(()=> {
+            var app_info = application.get_info();
+            if (app_info != null) {
+                DesktopHelper.set_pinned(settings, app_info, false);
+            }
         });
     }
 
     protected override bool on_button_release(Gdk.EventButton event)
     {
-        if (window == null)
-        {
+        if (!application.has_window_opened()) {
             if (event.button == 3) {
                 // Expose our own unpin option
                 alt_menu.popup(null, null, null, event.button, Gtk.get_current_event_time());
@@ -491,6 +372,7 @@ public class PinnedIconButton : IconButton
             }
             /* Launch ourselves. */
             try {
+                var app_info = application.get_info();
                 context.set_screen(get_screen());
                 context.set_timestamp(event.time);
                 var id = context.get_startup_notify_id(app_info, null);
@@ -506,26 +388,30 @@ public class PinnedIconButton : IconButton
         }
     }
 
-    public override void update_icon()
+    public override void reset()
     {
-        if (window != null) {
-            base.update_icon();
-            return;
-        }
-        image.pixel_size = icon_size;
-        queue_resize();
+        base.reset();
+        string launch_text = _("Launch");
+
+        set_tooltip_text("%s %s".printf(launch_text, application.get_info().get_display_name()));
+        id = null;
+        reset_icon();
     }
 
-    public void reset()
+    private void reset_icon()
     {
-        image.set_from_gicon(app_info.get_icon(), Gtk.IconSize.INVALID);
-        set_tooltip_text("Launch %s".printf(app_info.get_display_name()));
-        get_style_context().remove_class("running");
-        set_active(false);
-        // Actions menu
-        menu.destroy();
-        menu = null;
-        window = null;
-        id = null;
+        // setup the button's icon
+        image.set_from_gicon(application.get_info().get_icon(), Gtk.IconSize.INVALID);
+        update_icon_size(icon_size);
+    }
+
+    /**
+     * This function should be called when the first application window is opened
+     * to perform the initial configuration of the button.
+     */
+    public override void configure_button(ApplicationWindow appwin)
+    {
+        base.configure_button(appwin);
+        set_tooltip_text("");
     }
 }

--- a/panel/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/panel/applets/icon-tasklist/IconTasklistApplet.vala
@@ -1,13 +1,18 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  */
+
+public interface ApplicationManager
+{
+    public abstract bool app_info_update(Wnck.Window window, GLib.DesktopAppInfo app_info);
+}
 
 /**
  * Attempt to match startup notification IDs
@@ -71,7 +76,7 @@ public class DesktopHelper : Object
     }
 }
 
-public class IconTasklistApplet : Budgie.Applet
+public class IconTasklistApplet : Budgie.Applet, ButtonManager, WindowManager, ApplicationManager
 {
 
     protected Gtk.Box widget;
@@ -79,124 +84,26 @@ public class IconTasklistApplet : Budgie.Applet
     protected Gtk.Box pinned;
 
     protected Wnck.Screen screen;
-    protected HashTable<Wnck.Window,IconButton> buttons;
-    protected HashTable<string?,PinnedIconButton?> pin_buttons;
+
+    protected HashTable<string?,Application?> opened_apps;
+    protected HashTable<Wnck.Window,Application?> win_to_app_map;
+    protected HashTable<string?,Application?> pinned_apps;
+    // application objects waitting to be removed
+    protected Queue<Application?> tmp_apps;
+
     protected int icon_size = 32;
     private Settings settings;
+    protected string kPinningSettingsKey = "pinned-launchers";
 
     protected Gdk.AppLaunchContext context;
     protected AppSystem? helper;
 
-    private unowned IconButton? active_button;
+    private IconButton? active_button = null;
 
     public string uuid { public set ; public get ; }
+    private Budgie.PopoverManager? popover_manager = null;
 
-    protected void window_opened(Wnck.Window window)
-    {
-        // doesn't go on our list
-        if (window.is_skip_tasklist()) {
-            return;
-        }
-        string? launch_id = null;
-        IconButton? button = null;
-        if (window.get_application() != null) {
-            launch_id = window.get_application().get_startup_id();
-        }
-        var pinfo = helper.query_window(window);
 
-        // Check whether its launched with startup notification, if so
-        // attempt to use a pin button where appropriate.
-        if (launch_id != null) {
-            PinnedIconButton? btn = null;
-            PinnedIconButton? pbtn = null;
-            var iter = HashTableIter<string?,PinnedIconButton?>(pin_buttons);
-            while (iter.next(null, out pbtn)) {
-                if (pbtn.id != null && startupid_match(pbtn.id, launch_id)) {
-                    btn = pbtn;
-                    break;
-                }
-            }
-            if (btn != null) {
-                btn.window = window;
-                btn.update_from_window();
-                btn.id = null;
-                button = btn;
-            }
-        }
-        // Alternatively.. find a "free slot"
-        if (pinfo != null) {
-            var pinfo2 = pin_buttons[pinfo.get_id()];
-            if (pinfo2 != null && pinfo2.window == null) {
-                pinfo2.window = window;
-                pinfo2.update_from_window();
-                button = pinfo2;
-            }
-        }
-
-        // Fallback to new button.
-        if (button == null) {
-            var btn = new IconButton(settings, window, icon_size, pinfo, this.helper, panel_size);
-            var button_wrap = new ButtonWrapper(btn);
-
-            button = btn;
-            widget.pack_start(button_wrap, false, false, 0);
-        }
-        buttons[window] = button;
-        (button.get_parent() as Gtk.Revealer).set_reveal_child(true);
-        Idle.add(()=> {
-            button.icon_mapped();
-            return false;
-        });
-    }
-
-    protected void window_closed(Wnck.Window window)
-    {
-        IconButton? btn = null;
-        if (!buttons.contains(window)) {
-            return;
-        }
-        btn = buttons[window];
-        // We'll destroy a PinnedIconButton if it got unpinned
-        if (btn is PinnedIconButton && btn.get_parent() != widget) {
-            var pbtn = btn as PinnedIconButton;
-            pbtn.reset();
-        } else {
-            (btn.get_parent() as ButtonWrapper).gracefully_die();
-        }
-        buttons.remove(window);
-    }
-
-    /**
-     * Just update the active state on the buttons
-     */
-    protected void active_window_changed(Wnck.Window? previous_window)
-    {
-        IconButton? btn;
-        Wnck.Window? new_active;
-        if (previous_window != null)
-        {
-            // Update old active button
-            if (buttons.contains(previous_window)) {
-                btn = buttons[previous_window];
-                btn.set_active(false);
-            } 
-        }
-        new_active = screen.get_active_window();
-        if (new_active == null || !buttons.contains(new_active)) {
-            active_button = null;
-            queue_draw();
-            return;
-        }
-        btn = buttons[new_active];
-        btn.set_active(true);
-        if (!btn.get_realized()) {
-            btn.realize();
-            btn.queue_resize();
-        }
-
-        active_button = btn;
-        queue_draw();
-    }
 
     public IconTasklistApplet(string uuid)
     {
@@ -210,8 +117,11 @@ public class IconTasklistApplet : Budgie.Applet
         helper = new AppSystem();
 
         // Easy mapping :)
-        buttons = new HashTable<Wnck.Window,IconButton>(direct_hash, direct_equal);
-        pin_buttons = new HashTable<string?,PinnedIconButton?>(str_hash, str_equal);
+        opened_apps = new HashTable<string?, Application?>(str_hash, str_equal);
+        win_to_app_map = new HashTable<Wnck.Window, Application>(direct_hash, direct_equal);
+        pinned_apps = new HashTable<string?,Application?>(str_hash, str_equal);
+        tmp_apps = new Queue<Application?>();
+
 
         main_layout = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
         pinned = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 4);
@@ -252,25 +162,25 @@ public class IconTasklistApplet : Budgie.Applet
     {
         unowned Wnck.Window? btn_key = null;
         unowned string? str_key = null;
-        unowned IconButton? val = null;
-        unowned PinnedIconButton? pin_val = null;
+        unowned Application? app = null;
+        unowned Application? pin_app = null;
 
-        icon_size = small_icons;    
+        icon_size = small_icons;
         Wnck.set_default_icon_size(icon_size);
 
         Idle.add(()=> {
-            var iter = HashTableIter<Wnck.Window?,IconButton?>(buttons);
-            while (iter.next(out btn_key, out val)) {
-                val.icon_size = icon_size;
-                val.panel_size = panel_size;
-                val.update_icon();
+            var iter = HashTableIter<Wnck.Window?,Application?>(win_to_app_map);
+            while (iter.next(out btn_key, out app)) {
+                IconButton btn = app.get_button();
+                btn.panel_size = panel_size;
+                btn.update_icon_size(icon_size);
             }
 
-            var iter2 = HashTableIter<string?,PinnedIconButton?>(pin_buttons);
-            while (iter2.next(out str_key, out pin_val)) {
-                pin_val.icon_size = icon_size;
-                pin_val.panel_size = panel_size;
-                pin_val.update_icon();
+            var iter2 = HashTableIter<string?,Application?>(pinned_apps);
+            while (iter2.next(out str_key, out pin_app)) {
+                var btn = pin_app.get_button();
+                btn.panel_size = panel_size;
+                btn.update_icon_size(icon_size);
             }
             return false;
         });
@@ -352,7 +262,7 @@ public class IconTasklistApplet : Budgie.Applet
 
             var launcher = launchers[i];
 
-            (pin_buttons[launchers[i]].get_parent() as ButtonWrapper).get_allocation(out alloc);
+            (pinned_apps[launchers[i]].get_button().get_parent() as ButtonWrapper).get_allocation(out alloc);
 
             if(x <= (alloc.x + (alloc.width / 2) - main_layout_allocation.x)) {
 
@@ -385,93 +295,452 @@ public class IconTasklistApplet : Budgie.Applet
 
         Gtk.drag_finish(context, true, true, time);
     }
-
-    protected void on_settings_change(string key)
+    public override void update_popovers(Budgie.PopoverManager? new_manager)
     {
-        if (key != "pinned-launchers") {
-            return;
+        this.popover_manager = new_manager;
+        reregister_applications_window_list();
+    }
+
+    /**
+     * Re-register the Window List popovers of all opened Applications
+     */
+    private void reregister_applications_window_list()
+    {
+        Application? app;
+        // this map contains all openned apps, even those without an app_id
+        var iter = HashTableIter<Wnck.Window, Application?>(win_to_app_map);
+
+        while (iter.next(null, out app)) {
+            popover_manager.register_popover(app.get_button(), app.get_window_list_popover());
+        }
+    }
+
+    private void unregister_window_list(IconButton btn, Gtk.Popover popover)
+    {
+        // Make sure we hide the popover before we unregister it
+        if (popover.get_visible()) {
+            popover.hide();
         }
 
-        string[] files = settings.get_strv(key);
+        popover_manager.unregister_popover(btn);
+    }
+
+
+    private Application? get_pinned_application_by_startup_id(string startup_id)
+    {
+
+      PinnedIconButton? pbtn = null;
+      Application? pin_app;
+      var iter = HashTableIter<string?,Application?>(pinned_apps);
+
+      // iterate through the map of pinned buttons looking for the one
+      // matching startup_id
+      while (iter.next(null, out pin_app)) {
+          pbtn = (PinnedIconButton) pin_app.get_button();
+          if (pbtn.id != null && startupid_match(pbtn.id, startup_id)) {
+              return pin_app;
+          }
+      }
+
+      // no button associated with startup_id
+      return null;
+    }
+
+    private bool is_application_pinned(Application app)
+    {
+        var app_id = app.get_id ();
+        return (app_id != null && pinned_apps.contains(app_id));
+    }
+
+    private Application? get_pinned_application_by_id(string app_id)
+    {
+        return pinned_apps.contains (app_id) ? pinned_apps [app_id] : null;
+    }
+
+    private Application? get_pinned_application(string? startup_id, string? app_id)
+    {
+        Application? app = null;
+        if (startup_id != null) {
+            app = get_pinned_application_by_startup_id(startup_id);
+        }
+        // could not get by startup_id. Try using the app_id
+        if (app == null && app_id != null) {
+            app = get_pinned_application_by_id(app_id);
+        }
+
+        return app;
+    }
+
+    void register_window_opened(string? app_id, Wnck.Window window, Application app)
+    {
+        // associate the window with its parent application
+        win_to_app_map [window] = app;
+        if (app_id != null && !opened_apps.contains(app_id)) {
+            // first window of application. Application not registered as opened yet
+            opened_apps [app_id] = app;
+            // register the window list of the new application
+            popover_manager.register_popover(app.get_button(), app.get_window_list_popover());
+        }
+    }
+
+    void register_window_closed(string? app_id, Wnck.Window window, Application app)
+    {
+        bool is_last_win = (app.get_window_num() == 0);
+
+        if (app_id != null && is_last_win) {
+            // this was the last opened window of app_id. "Register" application
+            // as closed
+            opened_apps.remove(app_id);
+
+            // we just closed the last window of an application. Make sure we also
+            // hide its window list popover, if it is visible
+            var popover = app.get_window_list_popover();
+            if (popover.get_visible()) {
+                popover.hide();
+            }
+            // unregister window list
+            unregister_window_list(app.get_button(), app.get_window_list_popover());
+        }
+        // unregister window
+        win_to_app_map.remove(window);
+    }
+
+    /**
+     * Immense hack to make spotify play nicely. Returns true if we are going
+     * to keep using the same Application Object or false otherwise.
+     */
+    public bool app_info_update(Wnck.Window window, GLib.DesktopAppInfo app_info)
+    {
+        // this is a hack for properly registering spotify as opened
+        string app_id = app_info.get_id();
+        Application? old_app = null;
+
+        if (opened_apps.contains(app_id)) {
+            old_app = opened_apps [app_id];
+        } else if (pinned_apps.contains(app_id)) {
+            old_app = pinned_apps [app_id];
+        }
+
+        if (old_app != null) {
+            // application was either pinned or already opened. Either way,
+            // we are going to use the old application object
+            var new_app = win_to_app_map [window];
+            tmp_apps.push_tail(new_app);
+            new_app.remove_window(window);
+
+            if (new_app.get_button() == active_button) {
+                // the current window is the active one and since we are
+                // handing it over to the old_app instance, we should make old_app's
+                // button the active one
+                replace_active_button(old_app.get_button());
+            }
+            kill_button(new_app.get_button());
+
+            // Assign window to the older application
+            old_app.add_window(window);
+            register_window_opened(app_id, window, old_app);
+
+            Idle.add(() => {
+                // new_app is calling this function and since we removed it from
+                // the win_to_app_map HashTable, as soon as we go out of scope
+                // and return to new_app callee function, it will have gotten
+                // deallocated causing a segmentation fault. Thus, we hold a
+                // strong reference to it temporarily and shortly after we clear
+                // it, allowing new_app to be deallocated.
+                tmp_apps.clear();
+                return false;
+            });
+
+            // let callee know we are using a different application object
+            return false;
+        } else {
+            // application was not registered yet. Now with the app_id, register it
+            var app = win_to_app_map [window];
+            // re-register the application
+            register_window_opened(app_id, window, app);
+            // we continue to use the same application object
+            return true;
+        }
+    }
+
+    protected void window_opened(Wnck.Window window)
+    {
+        // doesn't go on our list
+        if (window.is_skip_tasklist()) {
+            return;
+        }
+        string? launch_id = null;
+        Application? application = null;
+
+        if (window.get_application() != null) {
+            launch_id = window.get_application().get_startup_id();
+        }
+        var pinfo = helper.query_window(window);
+        string? app_id = (pinfo != null) ? pinfo.get_id() : null;
+
+        // check if the app is already opened or if it is a pinned app. Either
+        // way we do not need add another button to the tray
+        if (app_id != null && opened_apps.contains(app_id)) {
+            application = opened_apps [app_id];
+            application.add_window(window);
+        } else if ((application = get_pinned_application(launch_id, app_id)) != null) {
+            application.add_window(window);
+        } else {
+            // Fallback to new button. Either the app is not pinned and was not opened
+            // or it is an app without id
+            var btn = new IconButton(settings, icon_size, this.helper, panel_size, this, this);
+            application = new Application(btn, this, pinfo, settings, this);
+            application.add_window(window);
+            var button_wrap = new ButtonWrapper(btn);
+
+            // add new button to tray and animate is appearence
+            widget.pack_start(button_wrap, false, false, 0);
+            (btn.get_parent() as Gtk.Revealer).set_reveal_child(true);
+        }
+
+        // register new window as opened
+        register_window_opened(app_id, window, application);
+    }
+
+    protected void window_closed(Wnck.Window window)
+    {
+        IconButton? btn = null;
+        Application? app = null;
+        if (!win_to_app_map.contains(window)) {
+            return;
+        }
+        app = win_to_app_map [window];
+        btn = app.get_button();
+        // unregister the window from application
+        app.remove_window(window);
+        // remove the registry of the window and if this is the last window of
+        // this app, also register the app as closed
+        register_window_closed(app.get_id(), window, app);
+
+        if (app.get_window_num() == 0 && !is_application_pinned(app)) {
+            // last window of non-pinned app was closed. Remove its button
+            kill_button(btn);
+        }
+    }
+
+    /**
+     * Just update the active state on the buttons
+     */
+    protected void active_window_changed(Wnck.Window? previous_window)
+    {
+        IconButton? btn;
+        Wnck.Window? new_active;
+
+        new_active = screen.get_active_window();
+        if (new_active != null && win_to_app_map.contains(new_active)) {
+            // get window associated with new active window
+            var app = win_to_app_map [new_active];
+            btn = app.get_button();
+            // make it the new active button
+            replace_active_button(btn);
+            // make the new active window the current window of the application
+            app.set_active_window(new_active);
+
+            if (!btn.get_realized()) {
+                btn.realize();
+                btn.queue_resize();
+            }
+        } else {
+            // there is no new active window or new window does not have a button
+            clear_active_button();
+        }
+        queue_draw();
+    }
+
+    /**
+     * Correctly removes a button. Disconnects all the callbacks registered
+     * in the button to prevent one of the to be called after the button is
+     * not suppose to exist anymore, e.g. size_allocation.
+     */
+    private void kill_button(IconButton btn)
+    {
+        (btn.get_parent() as ButtonWrapper).gracefully_die();
+        btn.reset_callbacks();
+    }
+
+    private void replace_active_button(IconButton btn)
+    {
+        clear_active_button();
+        active_button = btn;
+        active_button.set_active(true);
+    }
+
+    private void clear_active_button()
+    {
+        if (active_button != null) {
+            var tmp = active_button;
+            // just in case it calls toggle before assigning null
+            active_button = null;
+            tmp.set_active(false);
+        }
+    }
+
+    /**
+     * Tells btn if it is current active button
+     */
+    public bool can_become_active(IconButton btn){
+        return (btn == active_button);
+    }
+
+    /**
+     * Display the Window list of a given button
+     */
+    public void toggle_window_list(IconButton btn, Gtk.Popover popover)
+    {
+        if (popover.get_visible()) {
+            popover.hide();
+        } else {
+            popover_manager.show_popover(btn);
+        }
+    }
+
+    public void toggle_window(Wnck.Window window)
+    {
+        var timestamp = Gtk.get_current_event_time();
+        if (window.is_minimized()) {
+            window.unminimize(timestamp);
+            window.activate(timestamp);
+        } else {
+            if (window.is_active()) {
+                window.minimize();
+            } else {
+                window.activate(timestamp);
+            }
+        }
+    }
+
+    public void close_window(Wnck.Window win)
+    {
+        var timestamp = Gtk.get_current_event_time();
+        win.close(timestamp);
+    }
+
+    public DesktopAppInfo? query_window(Wnck.Window window)
+    {
+        return helper.query_window(window);
+    }
+
+    protected void replace_application_button(Application app, IconButton new_btn)
+    {
+
+        IconButton old_btn = app.get_button();
+        // Unregister popover associated with the old button
+        unregister_window_list(old_btn, app.get_window_list_popover());
+        // if old button is the active one, replace it by the new
+        if (old_btn == active_button) {
+            replace_active_button(new_btn);
+        }
+        // make the actual button replacement
+        app.replace_button(new_btn);
+        // update button popover
+        popover_manager.register_popover(new_btn, app.get_window_list_popover());
+    }
+
+    protected void insert_new_pinned_buttons(string [] files)
+    {
+
         /* We don't actually remove anything >_> */
-        foreach (string desktopfile in settings.get_strv(key)) {
+        foreach (string desktopfile in files) {
             /* Ensure we don't have this fella already. */
-            if (pin_buttons.contains(desktopfile)) {
+            if (pinned_apps.contains(desktopfile)) {
                 continue;
             }
             var info = new DesktopAppInfo(desktopfile);
             if (info == null) {
-                message("Invalid application! %s", desktopfile);
                 continue;
             }
-            var button = new PinnedIconButton(settings, info, icon_size, ref this.context, this.helper, panel_size);
+            var button = new PinnedIconButton(settings, icon_size, ref this.context, this.helper, panel_size, this, this);
             var button_wrap = new ButtonWrapper(button);
-            pin_buttons[desktopfile] = button;
-            pinned.pack_start(button_wrap, false, false, 0);
+            Application? pin_app = null;
 
-            // Do we already have an icon button for this?
-            var iter = HashTableIter<Wnck.Window,IconButton>(buttons);
-            Wnck.Window? keyn;
-            IconButton? btn;
-            while (iter.next(out keyn, out btn)) {
-                if (btn.ainfo == null) {
-                    continue;
-                }
-                if (btn.ainfo.get_id() == info.get_id() && btn.requested_pin) {
-                    // Pinning an already active button.
-                    button.window = btn.window;
-                    // destroy old one
-                    (btn.get_parent() as ButtonWrapper).gracefully_die();
-                    buttons.remove(keyn);
-                    buttons[keyn] = button;
-                    button.update_from_window();
-                    break;
-                }
+            if (opened_apps.contains(info.get_id())) {
+                // application being pinned is already opened
+                pin_app = opened_apps [info.get_id()];
+                var btn = pin_app.get_button();
+
+                // replace application's pinned button by a non-pinned version
+                replace_application_button(pin_app, button);
+                // destroy old one
+                kill_button(btn);
+            } else {
+                // there was no application opened with such id. Create a new
+                // application object
+                pin_app = new Application(button, this, info, settings, this);
             }
+            // register application as pinned
+            pinned_apps[desktopfile] = pin_app;
 
+            // add new pinned button to the tray
+            pinned.pack_start(button_wrap, false, false, 0);
             (button.get_parent() as Gtk.Revealer).set_reveal_child(true);
-            Idle.add(()=> {
-                button.icon_mapped();
-                return false;
-            });
         }
+    }
+
+    private void remove_unpinned_buttons(string [] files)
+    {
         string[] removals = {};
         /* Conversely, remove ones which have been unset. */
-        var iter = HashTableIter<string?,PinnedIconButton?>(pin_buttons);
+        var iter = HashTableIter<string?,Application?>(pinned_apps);
         string? key_name;
         PinnedIconButton? btn;
-        while (iter.next(out key_name, out btn)) {
+        Application? app;
+        while (iter.next(out key_name, out app)) {
             if (key_name in files) {
                 continue;
             }
+            btn = (PinnedIconButton) app.get_button();
             /* We have a removal. */
-            if (btn.window == null) {
-                (btn.get_parent() as ButtonWrapper).gracefully_die();
+            if (app.get_window_num() == 0) {
+                // removing button from a closed application
+                kill_button(btn);
             } else {
-                /* We need to move this fella.. */
-                IconButton b2 = new IconButton(settings, btn.window, icon_size, (owned)btn.app_info, this.helper, panel_size);
+                // application is opened. We need to create an IconButton for it
+                // in the non-pinned portion of the tray
+                IconButton b2 = new IconButton(settings, icon_size, this.helper, panel_size, this, this);
                 var button_wrap = new ButtonWrapper(b2);
+                // replace the application's pinned button by a non-pinned version
+                replace_application_button(app, b2);
 
-                (btn.get_parent() as ButtonWrapper).gracefully_die();
+                // remove the old, pinned, button
+                kill_button(btn);
+                // add the new non-pinned button
                 widget.pack_start(button_wrap, false, false, 0);
-                buttons[b2.window]  = b2;
                 button_wrap.set_reveal_child(true);
             }
             removals += key_name;
         }
 
-        foreach (string rkey in removals) {
-            pin_buttons.remove(rkey);
+        foreach (string rkey in removals)
+        {
+            pinned_apps.remove(rkey);
         }
+    }
+
+    protected void on_settings_change(string key)
+    {
+        if (key != kPinningSettingsKey) {
+            return;
+        }
+
+        // get current list of pinned apps
+        string[] files = settings.get_strv(kPinningSettingsKey);
+
+        insert_new_pinned_buttons(files);
+        remove_unpinned_buttons(files);
 
         /* Properly reorder the children */
         int j = 0;
         for (int i = 0; i < files.length; i++) {
             string lkey = files[i];
-            if (!pin_buttons.contains(lkey)) {
+            if (!pinned_apps.contains(lkey)) {
                 continue;
             }
-            unowned Gtk.Widget? parent = pin_buttons[lkey].get_parent();
+            unowned Gtk.Widget? parent = pinned_apps[lkey].get_button().get_parent();
             pinned.reorder_child(parent, j);
             ++j;
         }

--- a/panel/applets/icon-tasklist/Makefile.am
+++ b/panel/applets/icon-tasklist/Makefile.am
@@ -31,7 +31,16 @@ plugin_LTLIBRARIES = libicontasklistapplet.la
 libicontasklistapplet_la_SOURCES = \
 	AppSystem.vala \
 	IconTasklistApplet.vala \
-	Buttons.vala
+    Buttons.vala \
+    ButtonManager.vala \
+    WindowManager.vala \
+    WindowListView.vala \
+    WindowListItem.vala \
+    ApplicationWindow.vala \
+    WindowMenu.vala \
+    ApplicationWindowListeners.vala \
+    Application.vala \
+    UrgencyAnimation.vala
 
 libicontasklistapplet_la_CFLAGS = \
 	$(BUDGIE_BASE_CFLAGS) \

--- a/panel/applets/icon-tasklist/UrgencyAnimation.vala
+++ b/panel/applets/icon-tasklist/UrgencyAnimation.vala
@@ -1,0 +1,147 @@
+/*
+ * This file is part of budgie-desktop
+ *
+ * Copyright (C) 2016 Fernando Mussel <fernandomussel91@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * Maximum number of full flash cycles for urgency before giving up. Note
+ * that the background colour will remain fully opaque until the calling
+ * application then resets whatever caused the urgency/attention demand
+ */
+const int MAX_CYCLE = 12;
+
+/**
+ * Default opacity when beginning urgency cycles in the launcher
+ */
+const double DEFAULT_OPACITY = 0.1;
+const double INCREMENT = 0.01;
+
+class UrgencyAnimation
+{
+
+    public static const int INFINITE_CYCLE_NUM = -1;
+    private bool should_fade_in = true;
+
+    private double opacity = 0.0;
+    private int current_cycle = 0;
+    private int max_cycle_num = MAX_CYCLE;
+
+    private weak Gtk.Widget owner;
+    private uint source_id = 0;
+    private ulong owner_draw_cb = 0;
+
+    public UrgencyAnimation(Gtk.Widget owner, int max_cycle_num = MAX_CYCLE)
+    {
+        this.owner = owner;
+        this.max_cycle_num = max_cycle_num;
+        reset();
+    }
+
+    public void begin_animation()
+    {
+        if (!is_animation_in_progress()) {
+            // intercept the draw signal of the owner widget
+            owner_draw_cb = this.owner.draw.connect(draw);
+        }
+
+        if (source_id == 0) {
+            // no tick callback registered. Register new one.
+            source_id = owner.add_tick_callback(update);
+        }
+        reset();
+    }
+
+    public void end_animation()
+    {
+        if (is_animation_in_progress()) {
+            this.owner.disconnect(owner_draw_cb);
+            owner_draw_cb = 0;
+        }
+
+        stop_animation_update();
+        owner.queue_draw();
+    }
+
+    public bool is_animation_in_progress()
+    {
+        return owner_draw_cb > 0;
+    }
+
+    public double get_opacity()
+    {
+        return opacity;
+    }
+
+    private void stop_animation_update()
+    {
+        if (source_id > 0) {
+            owner.remove_tick_callback(source_id);
+        }
+        source_id = 0;
+    }
+
+    private bool update(Gtk.Widget widget, Gdk.FrameClock clock)
+    {
+
+        if (should_fade_in) {
+            opacity += INCREMENT;
+        } else {
+            opacity -= INCREMENT;
+        }
+
+        if (opacity >= 1.0) {
+            should_fade_in = false;
+            opacity = 1.0;
+            current_cycle += 1;
+        } else if (opacity <= 0.0) {
+            should_fade_in = true;
+            opacity = 0.0;
+        }
+
+        // prompt widget draw
+        owner.queue_draw();
+
+        if (max_cycle_num != INFINITE_CYCLE_NUM && current_cycle >= max_cycle_num
+            && opacity >= 1.0) {
+
+            stop_animation_update();
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool draw(Cairo.Context cr)
+    {
+        if (!is_animation_in_progress()) {
+            message ("Intercepting draw signal but animation is not in progress");
+            return false;
+        }
+
+        Gtk.Allocation alloc;
+        owner.get_allocation(out alloc);
+
+        Gdk.RGBA col = {};
+        /* FIXME: I'M ON DRUGS */
+        col.parse("#36689E");
+        cr.set_source_rgba(col.red, col.green, col.blue, get_opacity());
+        cr.rectangle(alloc.x, alloc.y, alloc.width, alloc.height);
+        cr.paint();
+        return false;
+    }
+
+    private void reset()
+    {
+        should_fade_in = true;
+        current_cycle = 0;
+        opacity = DEFAULT_OPACITY;
+    }
+
+
+}

--- a/panel/applets/icon-tasklist/WindowListItem.vala
+++ b/panel/applets/icon-tasklist/WindowListItem.vala
@@ -1,0 +1,138 @@
+/*
+ * This file is part of budgie-desktop
+ *
+ * Copyright (C) 2016 Fernando Mussel <fernandomussel91@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+public class WindowListItem: Gtk.Revealer, NameChangeListener
+{
+
+    private Gtk.Box layout;
+    private Gtk.Button window_switch_btn;
+    private Gtk.Label window_name_lbl;
+    private Gtk.Button window_close_btn;
+
+    private string window_name;
+    private unowned ApplicationWindow? appwin = null;
+    private unowned WindowManager? window_manager = null;
+    private UrgencyAnimation urgency_animation;
+
+    public WindowListItem(string window_name, ApplicationWindow appwin, WindowManager window_manager)
+    {
+        configure_window_switch_button();
+        configure_window_close_button();
+        urgency_animation = new UrgencyAnimation(this,
+                                                 UrgencyAnimation.INFINITE_CYCLE_NUM);
+        layout = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 10);
+
+        layout.pack_start(window_switch_btn, true, true, 0);
+        layout.pack_start(window_close_btn, true, true, 0);
+        set_window_name(window_name);
+        this.appwin = appwin;
+        this.window_manager = window_manager;
+
+        add(layout);
+        set_can_focus(false);
+        set_reveal_child(true);
+        // allows the glow of attention animation to surround the whole element
+        layout.set_border_width (1);
+        show_all();
+    }
+
+    public void gracefully_die(Gtk.ListBox lsbox)
+    {
+        // just in case
+        urgency_animation.end_animation();
+
+        if (!get_settings().gtk_enable_animations) {
+            lsbox.remove(this.get_parent());
+            return;
+        }
+
+        this.set_transition_type(Gtk.RevealerTransitionType.SLIDE_UP);
+        this.notify["child-revealed"].connect_after(()=> {
+            lsbox.remove(this.get_parent());
+        });
+        this.set_reveal_child(false);
+    }
+
+    private void configure_window_close_button()
+    {
+        window_close_btn = new Gtk.Button.from_icon_name("window-close",
+            Gtk.IconSize.SMALL_TOOLBAR);
+        window_close_btn.set_can_focus(false);
+
+        window_close_btn.tooltip_text = _("Close window");
+        window_close_btn.button_release_event.connect_after(close_window);
+    }
+
+    private void configure_window_switch_button()
+    {
+        window_switch_btn = new Gtk.Button();
+        window_name_lbl = new Gtk.Label("");
+        window_name_lbl.halign = Gtk.Align.CENTER;
+        window_switch_btn.add(window_name_lbl);
+        window_switch_btn.set_can_focus(false);
+
+        window_switch_btn.button_release_event.connect_after(switch_window);
+    }
+
+    public void name_changed(ApplicationWindow appwin, string new_name)
+    {
+        set_window_name(new_name);
+    }
+
+    public void set_window_name(string window_name)
+    {
+        if (window_name.char_count() > 50) {
+            this.window_name = window_name.substring(0, 46) + " ...";
+        } else {
+            this.window_name = window_name;
+        }
+
+        window_name_lbl.set_label(this.window_name);
+        window_switch_btn.set_tooltip_text(_("Switch to window:") + window_name);
+    }
+
+    public bool switch_window(Gdk.EventButton event)
+    {
+        window_manager.toggle_window(appwin.get_window());
+        return true;
+    }
+
+    public bool close_window(Gdk.EventButton event)
+    {
+        window_manager.close_window(appwin.get_window());
+        return true;
+    }
+
+    public ApplicationWindow get_application_window()
+    {
+        return appwin;
+    }
+
+    public void begin_attention_request()
+    {
+        urgency_animation.begin_animation();
+    }
+
+    public void end_attention_request()
+    {
+        urgency_animation.end_animation();
+    }
+
+    public void add_switch_button_to_group(Gtk.SizeGroup group)
+    {
+        group.add_widget(window_switch_btn);
+    }
+
+    public void remove_switch_button_from_group(Gtk.SizeGroup group)
+    {
+        group.remove_widget(window_switch_btn);
+    }
+}

--- a/panel/applets/icon-tasklist/WindowListView.vala
+++ b/panel/applets/icon-tasklist/WindowListView.vala
@@ -1,0 +1,149 @@
+/*
+ * This file is part of budgie-desktop
+ *
+ * Copyright (C) 2016 Fernando Mussel <fernandomussel91@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+public class WindowListView
+{
+
+    private unowned WindowManager? window_manager = null;
+
+    private Gtk.Popover? window_list_popover = null;
+    private Gtk.ListBox window_listbox;
+    private unowned Gtk.Widget owner;
+    private HashTable<unowned ApplicationWindow, unowned WindowListItem>? window_row_map = null;
+    private Gtk.SizeGroup switch_btn_group;
+    private Queue<Gtk.ListBoxRow> removed_items;
+
+    public WindowListView(Gtk.Widget owner, WindowManager window_manager)
+    {
+        this.owner = owner;
+        this.window_manager = window_manager;
+        window_row_map = new HashTable<unowned ApplicationWindow,unowned WindowListItem>(direct_hash, direct_equal);
+        configure_view();
+        removed_items = new Queue<Gtk.ListBoxRow>();
+    }
+
+    ~WindowListView()
+    {
+        clear_removed_items();
+    }
+
+    public uint get_window_num()
+    {
+        return window_row_map.size();
+    }
+
+    /**
+     * Add new WindowListItem associated with \p appwin
+     */
+    public void add_window(ApplicationWindow appwin)
+    {
+        WindowListItem win_row = add_window_list_item(appwin);
+
+        window_row_map [appwin] = win_row;
+        // set the row object as the listener for the window's name change
+        // event
+        appwin.set_name_change_listener(win_row);
+    }
+
+    /**
+     * Handles the view side operations required to add a new ListBoxRow associated
+     * with the supplied window
+     */
+    private WindowListItem add_window_list_item(ApplicationWindow appwin)
+    {
+        WindowListItem new_item = new WindowListItem(appwin.get_window().get_name(),
+                                                     appwin, window_manager);
+
+        // this ensures that the switch buttons of all WindowListItems will have
+        // the same length
+        new_item.add_switch_button_to_group(switch_btn_group);
+        window_listbox.insert(new_item, -1);
+        // prevent new_item's parent(ListBoxRow) to be focusable
+        new_item.get_parent().set_can_focus(false);
+        new_item.get_parent().show_all();
+
+        return new_item;
+    }
+
+    public void remove_window(ApplicationWindow appwin)
+    {
+        var list_row = window_row_map [appwin];
+
+        // Handles the removal, with animation, of WindowListItem from the ListBox
+        list_row.gracefully_die(window_listbox);
+        window_row_map.remove(appwin);
+        // hold item to prevent its destruction and the possible resize of the
+        // other elements in the switch_btn_group SizeGroup. Removed elements
+        // will be cleared after the popover is closed
+        removed_items.push_tail(list_row.get_parent() as Gtk.ListBoxRow);
+
+        if (get_window_num() == 0) {
+            // last element removed. Close Popover
+            if (window_list_popover.get_visible()) {
+                window_list_popover.hide();
+            }
+            // clear the references to removed items
+            clear_removed_items();
+        }
+    }
+
+    private void clear_removed_items()
+    {
+        // delete the reference of all the removed WindowListItems removed
+        // while the popover was opened
+        Gtk.ListBoxRow item;
+        while ((item = removed_items.pop_head()) != null) {
+            (item.get_child() as WindowListItem).remove_switch_button_from_group(switch_btn_group);
+        }
+    }
+
+    private void configure_view()
+    {
+        window_listbox = new Gtk.ListBox();
+        window_listbox.selection_mode = Gtk.SelectionMode.NONE;
+
+        window_list_popover = new Gtk.Popover(owner);
+        window_list_popover.add(window_listbox);
+        switch_btn_group = new Gtk.SizeGroup(Gtk.SizeGroupMode.BOTH);
+        switch_btn_group.set_ignore_hidden(false);
+
+        window_list_popover.closed.connect_after(on_popover_closed);
+        window_listbox.show_all();
+    }
+
+    private void on_popover_closed()
+    {
+        clear_removed_items();
+    }
+
+    public Gtk.Popover get_popover()
+    {
+        return window_list_popover;
+    }
+
+    public void begin_attention_request(ApplicationWindow appwin)
+    {
+        var row = window_row_map [appwin];
+        row.begin_attention_request();
+    }
+
+    public void end_attention_request(ApplicationWindow appwin)
+    {
+        var row = window_row_map [appwin];
+        row.end_attention_request();
+    }
+
+    public void replace_owner(Gtk.Widget new_owner)
+    {
+        window_list_popover.set_relative_to(new_owner);
+        owner = new_owner;
+    }
+}

--- a/panel/applets/icon-tasklist/WindowManager.vala
+++ b/panel/applets/icon-tasklist/WindowManager.vala
@@ -1,0 +1,19 @@
+/*
+ * This file is part of budgie-desktop
+ *
+ * Copyright (C) 2016 Fernando Mussel <fernandomussel91@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+public interface WindowManager
+{
+    public abstract void toggle_window_list(IconButton btn, Gtk.Popover popover);
+    public abstract void close_window(Wnck.Window win);
+    public abstract void toggle_window(Wnck.Window win);
+
+    public abstract DesktopAppInfo? query_window(Wnck.Window window);
+}

--- a/panel/applets/icon-tasklist/WindowMenu.vala
+++ b/panel/applets/icon-tasklist/WindowMenu.vala
@@ -1,0 +1,161 @@
+/*
+ * This file is part of budgie-desktop
+ *
+ * Copyright (C) 2016 Fernando Mussel <fernandomussel91@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+public interface ScreenProvider
+{
+    public abstract Gdk.Screen get_screen();
+}
+
+public class WindowMenu
+{
+    private unowned Wnck.Window window;
+
+    private Gtk.MenuItem close_all_windows_opt;
+    private Gtk.MenuItem pinnage;
+    private Gtk.MenuItem unpinnage;
+    private Gtk.SeparatorMenuItem sep_item;
+    private bool requested_pin = false;
+    private Wnck.ActionMenu menu;
+    private unowned GLib.DesktopAppInfo? app_info = null;
+    private unowned Settings settings;
+    private unowned ScreenProvider? screen_provider = null;
+    private unowned Application? application = null;
+    private bool pinning_enabled = false;
+    private bool unpinning_enabled = false;
+
+    public WindowMenu(Wnck.Window window, GLib.DesktopAppInfo? app_info,
+                      Settings settings, ScreenProvider? screen_provider,
+                      Application? application)
+    {
+        this.window = window;
+        this.settings = settings;
+        this.screen_provider = screen_provider;
+        this.application = application;
+        update_app_info(app_info);
+
+        build_application_menu(window, app_info);
+        disable_all_pinning_options();
+    }
+
+    /**
+     * I have no idea why, but this function MUST be called once we no longer
+     * need this menu, in order for the destructor of WindowMenu to be called.
+     * Perhaps there is a reference cycle between Wnck.Window and ActionMenu.
+     */
+    public void clear()
+    {
+        menu.destroy();
+    }
+
+    public void update_app_info(GLib.DesktopAppInfo? app_info)
+    {
+        this.app_info = app_info;
+    }
+
+    public void show(uint event_button, uint32 timestamp)
+    {
+        menu.popup(null, null, null, event_button, timestamp);
+    }
+
+    public void enable_pinning_option()
+    {
+        unpinnage.hide();
+        pinnage.show();
+        sep_item.show();
+
+        pinning_enabled = true;
+        unpinning_enabled = false;
+    }
+
+    public void enable_unpinning_option()
+    {
+        unpinnage.show();
+        pinnage.hide();
+        sep_item.show();
+
+        pinning_enabled = false;
+        unpinning_enabled = true;
+    }
+
+    public void disable_all_pinning_options()
+    {
+        unpinnage.hide();
+        pinnage.hide();
+        sep_item.hide();
+
+        pinning_enabled = false;
+        unpinning_enabled = false;
+    }
+
+    private void build_application_menu(Wnck.Window window, GLib.DesktopAppInfo? app_info)
+    {
+        // Actions menu
+        menu = new Wnck.ActionMenu(window);
+
+        var sep = new Gtk.SeparatorMenuItem();
+        menu.append(sep);
+        sep_item = sep;
+        close_all_windows_opt = new Gtk.MenuItem.with_label(_("Close All"));
+        pinnage = new Gtk.MenuItem.with_label(_("Pin to panel"));
+        unpinnage = new Gtk.MenuItem.with_label(_("Unpin from panel"));
+        sep.show();
+        close_all_windows_opt.show();
+        menu.append(close_all_windows_opt);
+        menu.append(pinnage);
+        menu.append(unpinnage);
+
+        close_all_windows_opt.activate.connect(()=> {
+            application.close_all_windows();
+        });
+        /* Handle running instance pin/unpin */
+        pinnage.activate.connect(()=> {
+            assert(pinning_enabled);
+            DesktopHelper.set_pinned(settings, app_info, true);
+        });
+
+        unpinnage.activate.connect(()=> {
+            assert(unpinning_enabled);
+            DesktopHelper.set_pinned(settings, app_info, false);
+        });
+
+        if (app_info != null) {
+            // Desktop app actions =)
+            unowned string[] actions = app_info.list_actions();
+            if (actions.length == 0) {
+                return;
+            }
+            sep = new Gtk.SeparatorMenuItem();
+            menu.append(sep);
+            sep.show_all();
+            foreach (var action in actions) {
+                var display_name = app_info.get_action_name(action);
+                var item = new Gtk.MenuItem.with_label(display_name);
+                item.set_data("__aname", action);
+                item.activate.connect(()=> {
+                    string? act = item.get_data("__aname");
+                    if (act == null) {
+                        return;
+                    }
+                    // Never know.
+                    if (app_info == null) {
+                        return;
+                    }
+                    var launch_context = Gdk.Screen.get_default().get_display().get_app_launch_context();
+                    launch_context.set_screen(screen_provider.get_screen());
+                    launch_context.set_timestamp(Gdk.CURRENT_TIME);
+                    app_info.launch_action(act, launch_context);
+                });
+                item.show_all();
+                menu.append(item);
+            }
+        }
+    }
+}

--- a/panel/panel.vala
+++ b/panel/panel.vala
@@ -952,22 +952,22 @@ public class Panel : Budgie.Toplevel
         }
         this.expanded = expanded;
         if (!expanded) {
-            if (wm_proxy != null) {
+            /*if (wm_proxy != null) {
                 try {
                     this.wm_proxy.restore_focused();
                 } catch (Error e) {
                     message("Error with wm_proxy: %s", e.message);
                 }
-            }
+            }*/
             scr = small_scr;
         } else {
-            if (wm_proxy != null) {
+            /*if (wm_proxy != null) {
                 try {
                     this.wm_proxy.store_focused();
                 } catch (Error e) {
                     message("Error with wm_proxy: %s", e.message);
                 }
-            }
+            }*/
             scr = orig_scr;
         }
 


### PR DESCRIPTION
This set of commits implements the window grouping functionality described in #439, where multiple windows of a given application share the same IconButton. To choose between windows, the user clicks in the application's button and a Popover appears with a list of the opened windows. 

The application menu (the one that appears by right-clicking the IconButton) operates on the "Current Window", i.e. the last window of an application that was active.

When a window needs attention, the applet will initiate the "urgency animation" in both the application's button and also the window's row in the aforementioned dropdown list. This allows the user to identify exactly which window is requesting the attention.

Lastly, I also managed to make Spotify behave nicely when pinned. As far as I can tell, in the master version of the tasklist applet it is possible to pin Spofity. However, when you open it, instead of using the PinnedIconButton already available, the applet was creating a new IconButton for Spotify. In this new version, once Spotify sets its window class, the applet is able to query its DesktopAppInfo and use it to find the PinnedIconButton already associated with Spotify and then use it, instead of creating a new button.


Now regarding the Pull Request itself.

 I Tried to cleanup the commit as best as I could and for the most part I think it is ok. However, I ended up making extensive changes to both Buttons.vala and IconTasklistApplet.vala files, due to refactoring and the architectural changes necessary to implement the new functionality.  I personally think the amount of changes these files is not ideal, but it would be non-trivial to make it tidier. Take a look and if you think I should split the changes into more commits I can give it a try.