### PR TITLE
Format options for clock applet

### DIFF
--- a/panel/applets/clock/Makefile.am
+++ b/panel/applets/clock/Makefile.am
@@ -10,22 +10,42 @@ plugin_DATA =
 	$(MKDIR_P) "$(dir $@)"; \
 	$(INTLTOOL_MERGE) $(top_srcdir)/po $< $@ -d -u -c $(top_builddir)/po/.intltool-merge-cache
 
-plugin_DATA += \
-	ClockApplet.plugin
 
-EXTRA_DIST += \
-	ClockApplet.plugin.in
+plugin_resources = $(shell glib-compile-resources --sourcedir=$(top_srcdir)/panel/applets/clock  --generate-dependencies $(top_srcdir)/panel/applets/clock/plugin.gresource.xml)
+
+# resources
+plugin-resources.h: $(top_srcdir)/panel/applets/clock/plugin.gresource.xml $(plugin_resources)
+	glib-compile-resources --target=$@ --sourcedir=$(top_srcdir)/panel/applets/clock --generate-header --c-name budgie_menu $<
+
+plugin-resources.c: $(top_srcdir)/panel/applets/clock/plugin.gresource.xml $(plugin_resources)
+	glib-compile-resources --target=$@ --sourcedir=$(top_srcdir)/panel/applets/clock --generate-source --c-name budgie_menu $<
+
+BUILT_SOURCES = \
+	plugin-resources.h \
+	plugin-resources.c
 
 CLEANFILES = \
+	$(BUILT_SOURCES) \
 	ClockApplet.plugin
 
 DISTCLEANFILES = \
 	ClockApplet.plugin
-	
+
+plugin_DATA += \
+	ClockApplet.plugin
+
+EXTRA_DIST += \
+	ClockApplet.plugin.in \
+	com.solus-project.clock.gschema.xml \
+	plugin.gresource.xml \
+	settings.ui
+
 plugin_LTLIBRARIES = libclockapplet.la
 
 libclockapplet_la_SOURCES = \
-	ClockApplet.vala
+	ClockApplet.vala \
+	plugin-resources.h \
+	plugin-resources.c
 
 libclockapplet_la_CFLAGS = \
 	$(BUDGIE_BASE_CFLAGS) \
@@ -47,4 +67,11 @@ libclockapplet_la_VALAFLAGS = \
 	--pkg libpeas-1.0 \
 	--pkg PeasGtk-1.0 \
 	--pkg budgie-1.0 \
-	--vapidir=${top_srcdir}/plugin
+	--vapidir=${top_srcdir}/plugin \
+	--target-glib=2.38 \
+	--gresources=${srcdir}/plugin.gresource.xml
+
+gsettings_SCHEMAS = \
+	com.solus-project.clock.gschema.xml
+
+@GSETTINGS_RULES@

--- a/panel/applets/clock/com.solus-project.clock.gschema.xml
+++ b/panel/applets/clock/com.solus-project.clock.gschema.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist gettext-domain="budgie">
+  <schema id="com.solus-project.clock">
+    <key type="b" name="show-week-day">
+      <default>false</default>
+      <summary>Show week day</summary>
+      <description>Show the day of week in clock applet</description>
+    </key>
+  </schema>
+</schemalist>

--- a/panel/applets/clock/plugin.gresource.xml
+++ b/panel/applets/clock/plugin.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+        <gresource prefix="/com/solus-project/clock">
+                <file preprocess="xml-stripblanks">settings.ui</file>
+        </gresource>
+</gresources>

--- a/panel/applets/clock/settings.ui
+++ b/panel/applets/clock/settings.ui
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.12"/>
+  <template class="ClockSettings" parent="GtkGrid">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="margin_left">8</property>
+    <property name="margin_right">4</property>
+    <property name="margin_top">4</property>
+    <property name="margin_bottom">4</property>
+    <property name="row_spacing">10</property>
+    <property name="column_spacing">6</property>
+    <child>
+      <object class="GtkLabel" id="date_label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Show date</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="date_switch">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="week_day_label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Show day of week</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="week_day_switch">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+  </template>
+</interface>


### PR DESCRIPTION
Small settings panel for clock applet's format options.
Allows to show date and week of day.