### PR TITLE
Raven spotify support

### DIFF
--- a/src/raven/mpris/MprisWidget.vala
+++ b/src/raven/mpris/MprisWidget.vala
@@ -34,7 +34,21 @@ public class MprisWidget : Gtk.Box
         int w = get_allocated_width();
         if (w > our_width) {
             our_width = w;
+
+            // Notify every client of the updated size. Idle needs to be used
+            // to prevent any 'queue_resize' triggered from being ignored
+            Idle.add(notify_clients_on_width_change);
         }
+    }
+
+    bool notify_clients_on_width_change()
+    {
+        var iter = HashTableIter<string,ClientWidget>(ifaces);
+        ClientWidget? widget = null;
+        while (iter.next(null, out widget)) {
+            widget.update_width(our_width);
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
This PR fixes the issue #560 

Regarding the bug on MprisWidget that I mentioned; I had to implement the first solution, i.e. MprisWidget notifies its clients of size changes. The second option was not working because 'queue_size' requests, even with the use of Idle, were being silently ignored. As a result, the cover
art was resized immediately after the size_allocate, but the drawing of the image was only updated once a widget was hovered. 

Even tough I fixed the aforementioned bug, I wanted your opinion on how the image size update is handled. What I did was simply reload the cover art by calling update_art again. For players that specify a local image or when we need to use the music icon, the new image is shown instantaneously. But if the art is remote, e.g. Spotify, this requires downloading the image again. This is done asynchronously, so there is no hang; but until the image is downloaded the one being exhibited has the wrong size, i.e. the black bars on the side. Since this happens only in a very specific scenario: Open Spotify before raven -> play song -> open raven for the first time; I thought this would not be a big deal. What do you guys think.
There are ways around this:
1. If the art is remote, we could upscale the pixbuf being exhibited instead of downloading a new image. But, the depending on the dimension difference, the image could be very blurry.
2. Upscale + download. This would be more expensive.
3. Change the image being shown to the music icon and then re-download the art.

I might be over-concerned with this minor issue, but I just wanted you guys to be aware of it.

EDIT: The delay in updating cover art for spotify is also present when skipping through the songs, meaning that the cover art of the previous song will be shown while the next art is being downloaded. If this behavior is also not adequate, tell me and we can come up with something to indicate that the new art's download is happening. ;)