### PR TITLE
check that schema and prefix have been previously created 

### DIFF
--- a/src/plugin/applet.c
+++ b/src/plugin/applet.c
@@ -231,7 +231,7 @@ GSettings *budgie_applet_get_applet_settings(BudgieApplet *self, gchar *uuid)
         GSettings *settings = NULL;
         gchar *path = NULL;
 
-        if (!self->priv->schema || !self->priv->prefix) {
+        if (!self || !self->priv || !self->priv->schema || !self->priv->prefix) {
                 return NULL;
         }
 

--- a/src/wm/keyboard.vala
+++ b/src/wm/keyboard.vala
@@ -283,7 +283,7 @@ public class KeyboardManager : GLib.Object
     {
         string engine_name;
         InputSource? current = sources.index(current_source);
-        if (current.ibus_engine != null) {
+        if (current != null && current.ibus_engine != null) {
             engine_name = current.ibus_engine;
         } else {
             engine_name = DEFAULT_ENGINE;


### PR DESCRIPTION
- when removing C based widgets the private objects are deleted before applet settings are interrogated.

fixes this issue - https://github.com/budgie-desktop/budgie-desktop-examples/issues/3

i.e. in my case - budgie-indicator-applet can now be successfully removed without the panel crashing.