### PR TITLE
Different hibernate icon for User Indicator Applet

### DIFF
--- a/src/applets/user-indicator/UserIndicatorWindow.vala
+++ b/src/applets/user-indicator/UserIndicatorWindow.vala
@@ -100,7 +100,7 @@ public class UserIndicatorWindow : Gtk.Popover {
 
         IndicatorItem lock_menu = new IndicatorItem(_("Lock"), "system-lock-screen-symbolic", false);
         IndicatorItem suspend_menu = new IndicatorItem(_("Suspend"), "media-playback-pause-symbolic", false);
-        IndicatorItem hibernate_menu = new IndicatorItem(_("Hibernate"), "media-playback-pause-symbolic", false);
+        IndicatorItem hibernate_menu = new IndicatorItem(_("Hibernate"), "document-save-symbolic", false);
         IndicatorItem reboot_menu = new IndicatorItem(_("Restart"), "media-playlist-repeat-symbolic", false);
         IndicatorItem shutdown_menu = new IndicatorItem(_("Shutdown"), "system-shutdown-symbolic", false);
 


### PR DESCRIPTION
The symbolic _Hibernate_ icon on **User Indicator Applet** was same symbolic icon as _Suspend_: [link to source file](https://github.com/budgie-desktop/budgie-desktop/blob/cf911df8d97d8b25333dff5e2122d96748b10e1a/src/applets/user-indicator/UserIndicatorWindow.vala#L103)

![media-playback-pause-symbolic](https://cdn.rawgit.com/snwh/faba-icon-theme/v4.1.2/Faba/symbolic/actions/media-playback-pause-symbolic.svg) [media-playback-pause-symbolic](https://github.com/snwh/faba-icon-theme/blob/v4.1.2/Faba/symbolic/actions/media-playback-pause-symbolic.svg)

This commit changes the _Hibernate_ icon to `document-save-symbolic` for differentiating it from _Suspend_:

![document-save-symbolic](https://cdn.rawgit.com/snwh/faba-icon-theme/v4.1.2/Faba/symbolic/actions/document-save-symbolic.svg) [document-save-symbolic](https://github.com/snwh/faba-icon-theme/blob/v4.1.2/Faba/symbolic/actions/document-save-symbolic.svg)