### PR TITLE
Make a graphical Alt+Tab working

### DIFF
--- a/src/daemon/budgie-daemon.gresource.xml
+++ b/src/daemon/budgie-daemon.gresource.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
         <gresource prefix="/com/solus-project/budgie/daemon">
+		<file preprocess="xml-stripblanks">tabswitcher.ui</file>
                 <file preprocess="xml-stripblanks">osd.ui</file>
         </gresource>
         <gresource prefix="/com/solus-project/budgie/endsession">

--- a/src/daemon/manager.vala
+++ b/src/daemon/manager.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright (C) 2016 Ikey Doherty <ikey@solus-project.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -26,6 +26,7 @@ public class ServiceManager : GLib.Object
     /* On Screen Display */
     Budgie.OSDManager? osd;
     Budgie.MenuManager? menus;
+    Budgie.TabSwitcher? switcher;
 
     /**
      * Construct a new ServiceManager and initialiase appropriately
@@ -43,6 +44,8 @@ public class ServiceManager : GLib.Object
         osd.setup_dbus();
         menus = new Budgie.MenuManager();
         menus.setup_dbus();
+        switcher = new Budgie.TabSwitcher();
+        switcher.setup_dbus();
     }
 
     /**

--- a/src/daemon/meson.build
+++ b/src/daemon/meson.build
@@ -21,6 +21,7 @@ daemon_sources = [
     'manager.vala',
     'menus.vala',
     'osd.vala',
+    'tabswitcher.vala',
     daemon_resources,
 ]
 

--- a/src/daemon/tabswitcher.ui
+++ b/src/daemon/tabswitcher.ui
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.12"/>
+  <template class="BudgieSwitcher" parent="GtkWindow">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkListBox" id="box">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">5</property>
+      </object>
+    </child>
+    <style>
+      <class name="budgie-switcher-window"/>
+    </style>
+  </template>
+</interface>

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -1,0 +1,211 @@
+/*
+ * This file is part of budgie-desktop
+ *
+ * Copyright (C) 2016 Ikey Doherty <ikey@solus-project.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+namespace Budgie
+{
+
+/**
+ * Default width for an OSD notification
+ */
+public const int SWITCHER_SIZE= 350;
+
+/**
+ * How long before the visible OSD expires, default is 2.5 seconds
+ */
+public const int SWITCHER_EXPIRE_TIME = 2500;
+
+/**
+ * Our name on the session bus. Reserved for Budgie use
+ */
+public const string SWITCHER_DBUS_NAME        = "org.budgie_desktop.TabSwitcher";
+
+/**
+ * Unique object path on OSD_DBUS_NAME
+ */
+public const string SWITCHER_DBUS_OBJECT_PATH = "/org/budgie_desktop/TabSwitcher";
+
+
+/**
+ * The BudgieOSD provides a very simplistic On Screen Display service, complying with the
+ * private GNOME Settings Daemon -> GNOME Shell protocol.
+ *
+ * In short, all elements of the permanently present window should be able to hide or show
+ * depending on the updated ShowOSD message, including support for a progress bar (level),
+ * icon, optional label.
+ *
+ * This OSD is used by gnome-settings-daemon to portray special events, such as brightness/volume
+ * changes, physical volume changes (disk eject/mount), etc. This special window should remain
+ * above all other windows and be non-interactive, allowing unobtrosive overlay of information
+ * even in full screen movies and games.
+ *
+ * Each request to ShowOSD will reset the expiration timeout for the OSD's current visibility,
+ * meaning subsequent requests to the OSD will keep it on screen in a natural fashion, allowing
+ * users to "hold down" the volume change buttons, for example.
+ */
+[GtkTemplate (ui = "/com/solus-project/budgie/daemon/tabswitcher.ui")]
+public class Switcher : Gtk.Window
+{
+
+    /**
+     * Track the primary monitor to show on
+     */
+    private int primary_monitor;
+
+    /**
+     * Construct a new Switcher widget
+     */
+    public Switcher()
+    {
+        Object(type: Gtk.WindowType.POPUP, type_hint: Gdk.WindowTypeHint.NOTIFICATION);
+        /* Skip everything, appear above all else, everywhere. */
+        resizable = false;
+        skip_pager_hint = true;
+        skip_taskbar_hint = true;
+        set_decorated(false);
+        set_keep_above(true);
+        stick();
+
+        /* Set up an RGBA map for transparency styling */
+        Gdk.Visual? vis = screen.get_rgba_visual();
+        if (vis != null) {
+            this.set_visual(vis);
+        }
+
+        /* Update the primary monitor notion */
+        screen.monitors_changed.connect(on_monitors_changed);
+
+        /* Set up size */
+        set_default_size(SWITCHER_SIZE, -1);
+        realize();
+
+        get_child().show_all();
+
+        /* Get everything into position prior to the first showing */
+        on_monitors_changed();
+    }
+
+    /**
+     * Monitors changed, find out the primary monitor, and schedule move of OSD
+     */
+    private void on_monitors_changed()
+    {
+        primary_monitor = screen.get_primary_monitor();
+        move_switcher();
+    }
+
+    /**
+     * Move the OSD into the correct position
+     */
+    public void move_switcher()
+    {
+        /* Find the primary monitor bounds */
+        Gdk.Screen sc = get_screen();
+        Gdk.Rectangle bounds;
+
+        sc.get_monitor_geometry(primary_monitor, out bounds);
+        Gtk.Allocation alloc;
+
+        get_child().get_allocation(out alloc);
+
+        /* For now just center it */
+        int x = bounds.x + ((bounds.width / 2) - (alloc.width / 2));
+        int y = bounds.y + ((int)(bounds.height * 0.85));
+        move(x, y);
+    }
+} /* End class OSD (BudgieOSD) */
+
+/**
+ * BudgieOSDManager is responsible for managing the BudgieOSD over d-bus, receiving
+ * requests, for example, from budgie-wm
+ */
+[DBus (name = "org.budgie_desktop.TabSwitcher")]
+public class TabSwitcher
+{
+    private Switcher? switcher_window = null;
+    private uint32 expire_timeout = 0;
+
+    [DBus (visible = false)]
+    public TabSwitcher()
+    {
+        switcher_window = new Switcher();
+    }
+
+    /**
+     * Own the OSD_DBUS_NAME
+     */
+    [DBus (visible = false)]
+    public void setup_dbus()
+    {
+        Bus.own_name(BusType.SESSION, Budgie.SWITCHER_DBUS_NAME, BusNameOwnerFlags.ALLOW_REPLACEMENT|BusNameOwnerFlags.REPLACE,
+            on_bus_acquired, ()=> {}, ()=> { warning("TabSwitcher could not take dbus!"); });
+    }
+
+    /**
+     * Acquired OSD_DBUS_NAME, register ourselves on the bus
+     */
+    private void on_bus_acquired(DBusConnection conn)
+    {
+        try {
+            conn.register_object(Budgie.SWITCHER_DBUS_OBJECT_PATH, this);
+        } catch (Error e) {
+            stderr.printf("Error registering TabSwitcher: %s\n", e.message);
+        }
+    }
+
+    /**
+     * Show the OSD on screen with the given parameters:
+     * icon: string Icon-name to use
+     * label: string Text to display, if any
+     * level: int32 Progress-level to display in the OSD
+     * monitor: int32 The monitor to display the OSD on (currently ignored)
+     */
+    public void PassItem(uint32 id)
+    {
+	message("Got id: %" + uint32.FORMAT + "", id);
+    }
+
+    public void ShowSwitcher(uint32 curr_xid)
+    {
+    	message("Next window: %" + uint32.FORMAT + "", curr_xid);
+        this.reset_switcher_expire(SWITCHER_EXPIRE_TIME);
+    }
+
+    /**
+     * Reset and update the expiration for the OSD timeout
+     */
+    private void reset_switcher_expire(int timeout_length)
+    {
+        if (expire_timeout > 0) {
+            Source.remove(expire_timeout);
+            expire_timeout = 0;
+        }
+        if (!switcher_window.get_visible()) {
+            switcher_window.move_switcher();
+        }
+        switcher_window.show();
+        expire_timeout = Timeout.add(timeout_length, this.switcher_expire);
+    }
+
+    /**
+     * Expiration timeout was met, so hide the OSD Window
+     */
+    private bool switcher_expire()
+    {
+        if (expire_timeout == 0) {
+            return false;
+        }
+        switcher_window.hide();
+        expire_timeout = 0;
+        return false;
+    }
+} /* End class OSDManager (BudgieOSDManager) */
+
+} /* End namespace Budgie */

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -68,10 +68,12 @@ public class Switcher : Gtk.Window
             }
             index++;
         }
+        /* Get the window, which should be activated and activate that */
         var active_window = Wnck.Window.get(xids.nth_data(index));
         uint32 time = (uint32)Gdk.x11_get_server_time(Gdk.get_default_root_window());
         active_window.activate(time);
 
+        /* Remove all items so if the widget gets shown again it starts from scratch */
         var children = box.get_children();
         foreach (var child in children) {
             child.destroy();
@@ -80,8 +82,10 @@ public class Switcher : Gtk.Window
         xids = null;
     }
 
+    /* Remove all items, so the hide method doesn't finds any active window and thus just exits */
     public void stop_switching()
     {
+        /* Remove all items so if the widget gets shown again it starts from scratch */
         var children = box.get_children();
         foreach (var child in children) {
             child.destroy();
@@ -156,6 +160,7 @@ public class Switcher : Gtk.Window
         move(x, y);
     }
 
+    /* Add a single item to the ListBox and the xid to the List */
     public void add(uint32 xid, string title)
     {
         if(this.visible == true) {
@@ -173,8 +178,10 @@ public class Switcher : Gtk.Window
         box.show_all();
     }
 
-    public void next_item(uint32 xid)
+    /* Switch focus to the item with the xid */
+    public void focus_item(uint32 xid)
     {
+        /* Get the index of the xid it will be the same as the one the widget has */
         int index = 0;
         while(index <= xids.length()) {
             if(xids.nth_data(index) == xid) {
@@ -241,7 +248,7 @@ public class TabSwitcher
      */
     public void ShowSwitcher(uint32 curr_xid)
     {
-        switcher_window.next_item(curr_xid);
+        switcher_window.focus_item(curr_xid);
         this.add_mod_key_watcher();
 
         switcher_window.show();
@@ -269,9 +276,11 @@ public class TabSwitcher
         // Check if alt or windows key is pressed 80 and 24 are the codes, getting these programmatically didn't worked out so this works
         if((int)modifiers != 80 && (int)modifiers != 24)
         {
+            /* All done now hide and stop the timer */
             switcher_window.hide();
             return false;
         }
+        /* restart the timeout */
         return true;
     }
 

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -18,9 +18,9 @@ namespace Budgie
 public const int SWITCHER_SIZE= 350;
 
 /**
- * How long before the visible SWITCHER expires, default is 1.5 seconds
+ * How long before the visible SWITCHER expires, default is 0.5 seconds
  */
-public const int SWITCHER_EXPIRE_TIME = 1500;
+public const int SWITCHER_EXPIRE_TIME = 500;
 
 /**
  * Our name on the session bus. Reserved for Budgie use

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright (C) 2017 taaem <taaem@mailbox.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -57,24 +57,37 @@ public class Switcher : Gtk.Window
      */
     private void on_hide()
     {
-    	var current = box.get_selected_row();
-    	int index = 0;
-    	while(index <= xids.length()) {
-    		if(current == box.get_row_at_index(index)) {
-    			break;
-    		}
-    		index++;
-    	}
+        var current = box.get_selected_row();
+        if(current == null){
+            return;
+        }
+        int index = 0;
+        while(index <= xids.length()) {
+            if(current == box.get_row_at_index(index)) {
+                break;
+            }
+            index++;
+        }
         var active_window = Wnck.Window.get(xids.nth_data(index));
-	uint32 time = (uint32)Gdk.x11_get_server_time(Gdk.get_default_root_window());
+        uint32 time = (uint32)Gdk.x11_get_server_time(Gdk.get_default_root_window());
         active_window.activate(time);
 
-	var children = box.get_children();
-    	foreach (var child in children) {
-    		child.destroy();
-    	}
+        var children = box.get_children();
+        foreach (var child in children) {
+            child.destroy();
+        }
 
-    	xids = null;
+        xids = null;
+    }
+
+    public void stop_switching()
+    {
+        var children = box.get_children();
+        foreach (var child in children) {
+            child.destroy();
+        }
+
+        xids = null;
     }
 
     /**
@@ -102,8 +115,7 @@ public class Switcher : Gtk.Window
         /* Update the primary monitor notion */
         screen.monitors_changed.connect(on_monitors_changed);
 
-	xids = new List<uint32> ();
-	titles = new List<string> ();
+        xids = new List<uint32> ();
 
         /* Set up size */
         set_default_size(SWITCHER_SIZE, -1);
@@ -146,31 +158,31 @@ public class Switcher : Gtk.Window
 
     public void add(uint32 xid, string title)
     {
-    	if(this.visible == true) {
-    		return;
-    	}
-    	if(xids == null) {
-		xids = new List<uint32> ();
-    	}
-    	xids.append(xid);
-    	Gtk.Label child = new Gtk.Label(null);
-	child.set_markup(title);
-    	box.insert(child, -1);
-    	box.show_all();
+        if(this.visible == true) {
+            return;
+        }
+        if(xids == null) {
+            xids = new List<uint32> ();
+        }
+        xids.append(xid);
+        Gtk.Label child = new Gtk.Label(null);
+        child.set_markup(title);
+        box.insert(child, -1);
+        box.show_all();
     }
 
     public void next_item(uint32 xid)
     {
-    	int index = 0;
-    	while(index <= xids.length()) {
-    		if(xids.nth_data(index) == xid) {
-    			break;
-    		}
-    		index++;
-    	}
+        int index = 0;
+        while(index <= xids.length()) {
+            if(xids.nth_data(index) == xid) {
+                break;
+            }
+            index++;
+        }
 
-	var new_row = box.get_row_at_index(index);
-	box.select_row(new_row);
+        var new_row = box.get_row_at_index(index);
+        box.select_row(new_row);
     }
 } /* End class Switcher (BudgieSwitcher) */
 
@@ -219,7 +231,7 @@ public class TabSwitcher
      */
     public void PassItem(uint32 id, string title)
     {
-    	switcher_window.add(id, title);
+        switcher_window.add(id, title);
     }
     /**
      * Show the SWITCHER on screen with the given parameters:
@@ -227,10 +239,15 @@ public class TabSwitcher
      */
     public void ShowSwitcher(uint32 curr_xid)
     {
-	switcher_window.next_item(curr_xid);
+        switcher_window.next_item(curr_xid);
         this.reset_switcher_expire(SWITCHER_EXPIRE_TIME);
     }
 
+    public void StopSwitcher()
+    {
+        switcher_window.stop_switching();
+        this.switcher_expire();
+    }
     /**
      * Reset and update the expiration for the Switcher timeout
      */
@@ -248,7 +265,7 @@ public class TabSwitcher
     }
 
     /**
-     * Expiration timeout was met, so hide the OSD Window
+     * Expiration timeout was met, so hide the Switcher Window
      */
     private bool switcher_expire()
     {

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -152,7 +152,7 @@ public class Switcher : Gtk.Window
 
         /* For now just center it */
         int x = bounds.x + ((bounds.width / 2) - (alloc.width / 2));
-        int y = bounds.y + ((int)(bounds.height * 0.85));
+        int y = bounds.y + ((int)(bounds.height * 0.5));
         move(x, y);
     }
 
@@ -167,6 +167,8 @@ public class Switcher : Gtk.Window
         xids.append(xid);
         Gtk.Label child = new Gtk.Label(null);
         child.set_markup(title);
+        child.set_margin_bottom(10);
+        child.set_margin_top(10);
         box.insert(child, -1);
         box.show_all();
     }

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -271,10 +271,10 @@ public class TabSwitcher
     private bool check_mod_key()
     {
         mod_timeout = 0;
-        Gdk.ModifierType modifiers;
-        Gdk.Display.get_default().get_device_manager().get_client_pointer().get_state(Gdk.get_default_root_window(), null, out modifiers);
+        Gdk.ModifierType modifier;
+        Gdk.Display.get_default().get_device_manager().get_client_pointer().get_state(Gdk.get_default_root_window(), null, out modifier);
         // Check if alt or windows key is pressed 80 and 24 are the codes, getting these programmatically didn't worked out so this works
-        if((int)modifiers != 80 && (int)modifiers != 24)
+        if((int)modifier != 80 && (int)modifier != 24 && (int)modifier != 81 && (int)modifier != 25)
         {
             /* All done now hide and stop the timer */
             switcher_window.hide();

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -245,8 +245,10 @@ public class TabSwitcher
 
     public void StopSwitcher()
     {
-        switcher_window.stop_switching();
-        this.switcher_expire();
+        if(expire_timeout  != 0) {
+            switcher_window.stop_switching();
+            this.switcher_expire();
+        }
     }
     /**
      * Reset and update the expiration for the Switcher timeout

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -1041,7 +1041,6 @@ public class BudgieWM : Meta.Plugin
         in_group.destroy();
         in_group = null;
 
-        this.stop_switch_windows();
         this.switch_workspace_completed();
     }
 
@@ -1049,6 +1048,9 @@ public class BudgieWM : Meta.Plugin
     public static const int SWITCH_TIMEOUT = 250;
     public override void switch_workspace(int from, int to, Meta.MotionDirection direction)
     {
+        // Stop the Switcher if it was showing
+        this.stop_switch_windows();
+
         int screen_width;
         int screen_height;
 

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -106,7 +106,7 @@ public interface Switcher: GLib.Object
 {
     public abstract async void PassItem(uint32 xid, string title) throws Error;
     public abstract async void ShowSwitcher(uint32 curr_xid) throws Error;
-
+    public abstract async void StopSwitcher() throws Error;
 }
 
 [CompactClass]
@@ -997,6 +997,11 @@ public class BudgieWM : Meta.Plugin
         switcher_proxy.ShowSwitcher(curr_xid);
     }
 
+    public void stop_switch_windows()
+    {
+        switcher_proxy.StopSwitcher();
+    }
+
 
     /* EVEN MORE LEVELS OF DERP. */
     Clutter.Actor? out_group = null;
@@ -1036,6 +1041,7 @@ public class BudgieWM : Meta.Plugin
         in_group.destroy();
         in_group = null;
 
+        this.stop_switch_windows();
         this.switch_workspace_completed();
     }
 

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -981,7 +981,8 @@ public class BudgieWM : Meta.Plugin
             return;
         }
         foreach (var tab in cur_tabs) {
-            switcher_proxy.PassItem(tab.get_user_time());
+            uint32 xid = (uint32)tab.get_xwindow();
+            switcher_proxy.PassItem(xid);
         }
         cur_index++;
         if (cur_index > cur_tabs.length()-1) {
@@ -992,7 +993,8 @@ public class BudgieWM : Meta.Plugin
             return;
         }
 
-        switcher_proxy.ShowSwitcher(win.get_user_time());
+        uint32 curr_xid = (uint32)win.get_xwindow();
+        switcher_proxy.ShowSwitcher(curr_xid);
         //win.activate(display.get_current_time());
 
     }

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -980,19 +980,20 @@ public class BudgieWM : Meta.Plugin
         if (cur_tabs == null) {
             return;
         }
-        foreach (var tab in cur_tabs) {
-            uint32 xid = (uint32)tab.get_xwindow();
-            switcher_proxy.PassItem(xid, tab.get_title());
+        /* Pass each window over to tabswitcher */
+        foreach (var child in cur_tabs) {
+            uint32 xid = (uint32)child.get_xwindow();
+            switcher_proxy.PassItem(xid, child.get_title());
         }
         cur_index++;
         if (cur_index > cur_tabs.length()-1) {
             cur_index = 0;
         }
+        /* Get the new selected window over to TabSwitcher */
         var win = cur_tabs.nth_data(cur_index);
         if (win == null) {
             return;
         }
-
         uint32 curr_xid = (uint32)win.get_xwindow();
         switcher_proxy.ShowSwitcher(curr_xid);
     }

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -104,7 +104,7 @@ public interface MenuManager: GLib.Object
 [DBus (name = "org.budgie_desktop.TabSwitcher")]
 public interface Switcher: GLib.Object
 {
-    public abstract async void PassItem(uint32 xid) throws Error;
+    public abstract async void PassItem(uint32 xid, string title) throws Error;
     public abstract async void ShowSwitcher(uint32 curr_xid) throws Error;
 
 }
@@ -982,7 +982,7 @@ public class BudgieWM : Meta.Plugin
         }
         foreach (var tab in cur_tabs) {
             uint32 xid = (uint32)tab.get_xwindow();
-            switcher_proxy.PassItem(xid);
+            switcher_proxy.PassItem(xid, tab.get_title());
         }
         cur_index++;
         if (cur_index > cur_tabs.length()-1) {
@@ -995,8 +995,6 @@ public class BudgieWM : Meta.Plugin
 
         uint32 curr_xid = (uint32)win.get_xwindow();
         switcher_proxy.ShowSwitcher(curr_xid);
-        //win.activate(display.get_current_time());
-
     }
 
 


### PR DESCRIPTION
So this works and has a UI to be able to select the new window which can be cycled by pressing alt+tab multiple times. This *should* fix the random order, since this only updates the timestamp of the windows the user *actually* wants to visit. And yeah i mostly pulled the whole work out to budgie-daemon and budgie-wm is only responsible for getting the windows and grabbing the shortcut. It then sends all the data over dbus to budgie-daemon which does all the magic.
This way there is no added Gtk Code in budgie-wm which could break budgie-wm on an update.

![bildschirmaufnahme vom 2017-04-15 17 54 13](https://cloud.githubusercontent.com/assets/7108647/25064883/a5e9348c-2204-11e7-85c6-e056ed967351.png)
