### PR TITLE
fix spelling typo reseting --> resetting

### DIFF
--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -314,7 +314,7 @@ public class PanelManager : DesktopManager
      */
     void do_reset()
     {
-        GLib.message("Reseting budgie-panel configuration to defaults");
+        GLib.message("Resetting budgie-panel configuration to defaults");
         Settings s = new Settings(Budgie.ROOT_SCHEMA);
         this.reset_dconf_path(s);
     }


### PR DESCRIPTION
linitian error when making the 10.3 debian package

curious also lintian also reporting "Udpating" typo in libstatusapplet.so and also libraven0 but I can't find these typo's in the source tree.  weird.