### PR TITLE
hope i can configure to disable the 'super' key function in ubuntu budgie 17.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,6 @@ of each source file.
 Authors
 =======
 
-Copyright © 2014-2016 Ikey Doherty, Solus Project & Others
+Copyright © 2014-2017 Ikey Doherty, Solus Project & Others
 
 Also see our [contributors graph](https://github.com/solus-project/budgie-desktop/graphs/contributors)!

--- a/docs/budgie-desktop-docs.sgml
+++ b/docs/budgie-desktop-docs.sgml
@@ -8,7 +8,7 @@
   <bookinfo>
     <title>budgie-desktop Reference Manual</title>
     <releaseinfo>
-      Reference Manual for budgie-desktop 10.3
+      Reference Manual for budgie-desktop 10.3.1
       The latest version of this documentation can be found on-line at
       <ulink role="online-location" url="http://solus-project.github.io/budgie-desktop/index.html">http://solus-project.github.io/budgie-desktop/</ulink>.
     </releaseinfo>

--- a/docs/budgie-desktop-docs.sgml
+++ b/docs/budgie-desktop-docs.sgml
@@ -8,7 +8,7 @@
   <bookinfo>
     <title>budgie-desktop Reference Manual</title>
     <releaseinfo>
-      Reference Manual for budgie-desktop 10.2.9
+      Reference Manual for budgie-desktop 10.3
       The latest version of this documentation can be found on-line at
       <ulink role="online-location" url="http://solus-project.github.io/budgie-desktop/index.html">http://solus-project.github.io/budgie-desktop/</ulink>.
     </releaseinfo>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'budgie-desktop',
     ['c', 'vala'],
-    version: '10.3',
+    version: '10.3.1',
     license: [
         'GPL-2.0',
         'LGPL-2.1',

--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,9 @@ dep_peas = dependency('libpeas-1.0', version: '>= 1.8.0')
 dep_gdkx11 = dependency('gdk-x11-3.0', version: gnome_minimum_version)
 dep_libuuid = dependency('uuid')
 
+# gtk 3.22 needed for popup/popdown methods
+dep_gtk322 = dependency('gtk+-3.0', version: '>= 3.22.0', required: false)
+
 # Needed for keyboardy bits
 dep_ibus = dependency('ibus-1.0', verion: '>= 1.5.10')
 dep_gnomedesktop = dependency('gnome-desktop-3.0', version: gnome_minimum_version)

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'budgie-desktop',
     ['c', 'vala'],
-    version: '10.2.9',
+    version: '10.3',
     license: [
         'GPL-2.0',
         'LGPL-2.1',

--- a/mkrelease.sh
+++ b/mkrelease.sh
@@ -5,7 +5,7 @@ git submodule init
 git submodule update
 
 # Script for ikey because he went with meson. *shrug*
-VERSION="10.3"
+VERSION="10.3.1"
 NAME="budgie-desktop"
 git-archive-all.sh --format tar --prefix ${NAME}-${VERSION}/ --verbose -t HEAD ${NAME}-${VERSION}.tar
 xz -9 "${NAME}-${VERSION}.tar"

--- a/mkrelease.sh
+++ b/mkrelease.sh
@@ -5,7 +5,7 @@ git submodule init
 git submodule update
 
 # Script for ikey because he went with meson. *shrug*
-VERSION="10.2.9"
+VERSION="10.3"
 NAME="budgie-desktop"
 git-archive-all.sh --format tar --prefix ${NAME}-${VERSION}/ --verbose -t HEAD ${NAME}-${VERSION}.tar
 xz -9 "${NAME}-${VERSION}.tar"

--- a/mkrelease.sh
+++ b/mkrelease.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+git submodule init
+git submodule update
+
+# Script for ikey because he went with meson. *shrug*
+VERSION="10.2.9"
+NAME="budgie-desktop"
+git-archive-all.sh --format tar --prefix ${NAME}-${VERSION}/ --verbose -t HEAD ${NAME}-${VERSION}.tar
+xz -9 "${NAME}-${VERSION}.tar"
+
+gpg --armor --detach-sign "${NAME}-${VERSION}.tar.xz"
+gpg --verify "${NAME}-${VERSION}.tar.xz.asc"               

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -15,6 +15,8 @@ eu
 fi
 fr_FR
 fr
+gl_ES
+gl
 he
 hu
 id_ID

--- a/po/de.po
+++ b/po/de.po
@@ -3,6 +3,9 @@
 # This file is distributed under the same license as the PACKAGE package.
 # 
 # Translators:
+# Alfred Feldmeyer <alfred.feldmeyer@webtaurus.de>, 2016
+# Benni Bennson <benjaminwill@mail.de>, 2017
+# Casio E <casiopopasio@t-online.de>, 2016
 # Charles Aymard <charles.aymard80@gmail.com>, 2015
 # Christian Kaindl <crisscross.kaindl@outlook.de>, 2015
 # Denny T <denny.trebbin@gmail.com>, 2015
@@ -19,127 +22,127 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Budgie Desktop\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-10 22:09+0100\n"
-"PO-Revision-Date: 2016-10-12 17:15+0000\n"
-"Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
-"Language-Team: German (http://www.transifex.com/solus-project/budgie-desktop/language/de/)\n"
+"POT-Creation-Date: 2016-10-26 04:02+0100\n"
+"PO-Revision-Date: 2017-04-14 16:37+0000\n"
+"Last-Translator: Benni Bennson <benjaminwill@mail.de>\n"
+"Language-Team: German (http://www.transifex.com/budgie-desktop/budgie-desktop/language/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../daemon/endsession.vala:167
+#: ../src/daemon/endsession.vala:167
 msgid "Log out"
 msgstr "Abmelden"
 
-#: ../daemon/endsession.vala:171
+#: ../src/daemon/endsession.vala:171
 msgid "Restart device"
 msgstr "Gerät neu starten"
 
-#: ../daemon/endsession.vala:183 ../daemon/endsession.ui.h:1
+#: ../src/daemon/endsession.vala:183 ../src/daemon/endsession.ui.h:1
 msgid "Power Off"
 msgstr "Ausschalten"
 
-#: ../raven/main_view.vala:72 ../raven/ui/panel.ui.h:7
+#: ../src/raven/main_view.vala:72 ../src/raven/ui/panel.ui.h:7
 msgid "Applets"
 msgstr "Applets"
 
-#: ../raven/main_view.vala:75
-#: ../panel/applets/notifications/NotificationsApplet.plugin.in.h:1
+#: ../src/raven/main_view.vala:75
+#: ../src/panel/applets/notifications/NotificationsApplet.plugin.in.h:1
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
-#: ../raven/settings_view.vala:266
+#: ../src/raven/settings_view.vala:266
 msgid "Top"
 msgstr "Oben"
 
-#: ../raven/settings_view.vala:268
+#: ../src/raven/settings_view.vala:268
 msgid "Bottom"
 msgstr "Unten"
 
-#: ../raven/settings_view.vala:376
+#: ../src/raven/settings_view.vala:376
 msgid "Top Panel"
 msgstr "Leiste oben"
 
-#: ../raven/settings_view.vala:378
+#: ../src/raven/settings_view.vala:378
 msgid "Right Panel"
 msgstr "Leiste rechts"
 
-#: ../raven/settings_view.vala:380
+#: ../src/raven/settings_view.vala:380
 msgid "Left Panel"
 msgstr "Leiste links"
 
-#: ../raven/settings_view.vala:382
+#: ../src/raven/settings_view.vala:382
 msgid "Bottom Panel"
 msgstr "Leiste unten"
 
-#: ../raven/settings_view.vala:616
+#: ../src/raven/settings_view.vala:616
 msgid "Start"
 msgstr "Start"
 
-#: ../raven/settings_view.vala:619
+#: ../src/raven/settings_view.vala:619
 msgid "Center"
 msgstr "Zentriert"
 
-#: ../raven/settings_view.vala:622
+#: ../src/raven/settings_view.vala:622
 msgid "End"
 msgstr "Ende"
 
 #. Appearance expander
-#: ../raven/settings_view.vala:960
+#: ../src/raven/settings_view.vala:960
 msgid "Appearance"
 msgstr "Erscheinungsbild"
 
-#: ../raven/settings_view.vala:967
+#: ../src/raven/settings_view.vala:967
 msgid "Background"
 msgstr "Hintergrund"
 
-#: ../raven/settings_view.vala:974
+#: ../src/raven/settings_view.vala:974
 msgid "Fonts"
 msgstr "Schriftarten"
 
-#: ../raven/settings_view.vala:980
+#: ../src/raven/settings_view.vala:980
 msgid "Windows"
 msgstr "Fenster"
 
-#: ../raven/settings_view.vala:984
+#: ../src/raven/settings_view.vala:984
 msgid "General"
 msgstr "Allgemein"
 
-#: ../raven/settings_view.vala:995 ../raven/settings_view.vala:996
+#: ../src/raven/settings_view.vala:995 ../src/raven/settings_view.vala:996
 msgid "Panel"
 msgstr "Leiste"
 
-#: ../raven/notifications_view.vala:52
+#: ../src/raven/notifications_view.vala:74
 msgid "Nothing to see here"
 msgstr "Keine Benachrichtigungen"
 
-#: ../raven/notifications_view.vala:494
-#: ../panel/applets/notifications/NotificationsApplet.vala:75
+#: ../src/raven/notifications_view.vala:516
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:75
 #, c-format
 msgid "%u unread notifications"
 msgstr "%u ungelesene Benachrichtigungen"
 
-#: ../raven/notifications_view.vala:496
-#: ../panel/applets/notifications/NotificationsApplet.vala:77
+#: ../src/raven/notifications_view.vala:518
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:77
 msgid "1 unread notification"
 msgstr "1 ungelesene Benachrichtigung"
 
-#: ../raven/notifications_view.vala:498
-#: ../panel/applets/notifications/NotificationsApplet.vala:79
+#: ../src/raven/notifications_view.vala:520
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:79
 msgid "No unread notifications"
 msgstr "Keine ungelesenen Benachrichtigungen"
 
-#: ../raven/notifications_view.vala:624
+#: ../src/raven/notifications_view.vala:646
 msgid "No new notifications"
 msgstr "Keine neuen Benachrichtigungen"
 
-#: ../raven/sound.vala:78
+#: ../src/raven/sound.vala:78
 msgid "Output"
 msgstr "Ausgabe"
 
-#: ../raven/sound.vala:95
+#: ../src/raven/sound.vala:95
 msgid "Input"
 msgstr "Eingabe"
 
@@ -154,304 +157,306 @@ msgstr "Eingabe"
 #. *
 #. * vi: set shiftwidth=4 tabstop=4 expandtab:
 #. * :indentSize=4:tabSize=4:noTabs=true:
-#: ../panel/applets/spacer/settings.ui.h:1
+#: ../src/panel/applets/spacer/settings.ui.h:1
 msgid "Spacer size"
 msgstr "Platzhaltergröße"
 
-#: ../raven/ui/settings.ui.h:1
+#: ../src/raven/ui/settings.ui.h:1
 msgid "Budgie Settings"
 msgstr "Budgie Einstellungen"
 
-#: ../raven/ui/settings.ui.h:2
+#: ../src/raven/ui/settings.ui.h:2
 msgid "Exit"
 msgstr "Schließen"
 
-#: ../raven/ui/applets.ui.h:1
+#: ../src/raven/ui/applets.ui.h:1
 msgid "Add new applet"
 msgstr "Applet hinzufügen"
 
-#: ../raven/ui/appearance.ui.h:1
+#: ../src/raven/ui/appearance.ui.h:1
 msgid "Use the dark theme"
 msgstr "Dunkles Thema verwenden"
 
-#: ../raven/ui/appearance.ui.h:2
+#: ../src/raven/ui/appearance.ui.h:2
 msgid "Dark theme"
 msgstr "Dunkles Thema"
 
-#: ../raven/ui/appearance.ui.h:3
+#: ../src/raven/ui/appearance.ui.h:3
 msgid "Select a GTK+ theme"
 msgstr "Ein GTK+ Thema auswählen"
 
-#: ../raven/ui/appearance.ui.h:4
+#: ../src/raven/ui/appearance.ui.h:4
 msgid "Widget Theme"
 msgstr "Widget-Thema"
 
-#: ../raven/ui/appearance.ui.h:5
+#: ../src/raven/ui/appearance.ui.h:5
 msgid "Select an icon theme"
 msgstr "Ein Symbol-Thema auswählen"
 
-#: ../raven/ui/appearance.ui.h:6
+#: ../src/raven/ui/appearance.ui.h:6
 msgid "Icon Theme"
 msgstr "Symbol-Thema"
 
-#: ../raven/ui/appearance.ui.h:7
+#: ../src/raven/ui/appearance.ui.h:7
 msgid "Override defaults"
 msgstr "Voreinstellungen überschreiben"
 
-#: ../raven/ui/appearance.ui.h:8
+#: ../src/raven/ui/appearance.ui.h:8
 msgid "Built-in theme"
 msgstr "Eingebautes Thema"
 
-#: ../raven/ui/appearance.ui.h:9
+#: ../src/raven/ui/appearance.ui.h:9
 msgid "Select a cursor theme"
 msgstr "Wählen Sie ein Mauszeigerthema aus"
 
-#: ../raven/ui/appearance.ui.h:10
+#: ../src/raven/ui/appearance.ui.h:10
 msgid "Cursor Theme"
 msgstr "Mauszeigerthema"
 
-#: ../raven/ui/panel.ui.h:1
+#: ../src/raven/ui/panel.ui.h:1
 msgid "Manage Panels"
 msgstr "Leisten verwalten"
 
-#: ../raven/ui/panel.ui.h:2
+#: ../src/raven/ui/panel.ui.h:2
 msgid "Position"
 msgstr "Position"
 
-#: ../raven/ui/panel.ui.h:3
+#: ../src/raven/ui/panel.ui.h:3
 msgid "Size"
 msgstr "Größe"
 
-#: ../raven/ui/panel.ui.h:4
+#: ../src/raven/ui/panel.ui.h:4
 msgid "Shadow"
 msgstr "Schatten"
 
-#: ../raven/ui/panel.ui.h:5
+#: ../src/raven/ui/panel.ui.h:5
 msgid "Autohide policy"
 msgstr "Ausblend-Verhalten"
 
-#: ../raven/ui/panel.ui.h:6
+#: ../src/raven/ui/panel.ui.h:6
 msgid "Stylize regions"
 msgstr "Regionen stilisieren"
 
-#: ../raven/ui/background.ui.h:1
+#: ../src/raven/ui/background.ui.h:1
 msgid "Show desktop icons"
 msgstr "Desktopsymbole anzeigen"
 
-#: ../raven/ui/background.ui.h:2
+#: ../src/raven/ui/background.ui.h:2
 msgid "Desktop Icons"
 msgstr "Desktopsymbole"
 
-#: ../raven/ui/fonts.ui.h:1
+#: ../src/raven/ui/fonts.ui.h:1
 msgid "Window Titles"
 msgstr "Fenstertitel"
 
-#: ../raven/ui/fonts.ui.h:2
+#: ../src/raven/ui/fonts.ui.h:2
 msgid "Interface"
 msgstr "Oberfläche"
 
-#: ../raven/ui/fonts.ui.h:3
+#: ../src/raven/ui/fonts.ui.h:3
 msgid "Documents"
 msgstr "Dokumente"
 
-#: ../raven/ui/fonts.ui.h:4
+#: ../src/raven/ui/fonts.ui.h:4
 msgid "Monospace"
 msgstr "Monospace"
 
-#: ../raven/ui/wm.ui.h:1
+#: ../src/raven/ui/wm.ui.h:1
 msgid "Disable unredirect of fullscreen windows"
-msgstr ""
+msgstr "Deaktiviere die Weiterleitung von Vollbild-Fenstern"
 
-#: ../raven/ui/wm.ui.h:2
+#: ../src/raven/ui/wm.ui.h:2
 msgid "Disable unredirect"
-msgstr ""
+msgstr "Deaktiviere Weiterleitung"
 
-#: ../raven/ui/wm.ui.h:3
+#: ../src/raven/ui/wm.ui.h:3
 msgid "Change the layout of the window buttons"
-msgstr ""
+msgstr "Anordnung der Fenstersteuerungselemente ändern"
 
-#: ../raven/ui/wm.ui.h:4
+#: ../src/raven/ui/wm.ui.h:4
 msgid "Button layout"
 msgstr "Schaltflächenanordnung"
 
-#: ../session/budgie-desktop.desktop.in.in.h:1
-#: ../session/budgie-desktop.session.in.in.h:1
+#: ../src/session/budgie-desktop.desktop.in.in.h:1
+#: ../src/session/budgie-desktop.session.in.in.h:1
 msgid "Budgie Desktop"
 msgstr "Budgie Desktop"
 
-#: ../session/budgie-desktop.desktop.in.in.h:2
+#: ../src/session/budgie-desktop.desktop.in.in.h:2
 msgid "This session logs you into the Budgie Desktop"
 msgstr "Diese Sitzung loggt dich in den Budgie Desktop ein"
 
-#: ../daemon/endsession.ui.h:2
+#: ../src/daemon/endsession.ui.h:2
 msgid "Are you sure you want to end your session?"
 msgstr "Sind Sie sich sicher, dass Sie Ihre Sitzung beenden möchten?"
 
-#: ../daemon/endsession.ui.h:3
+#: ../src/daemon/endsession.ui.h:3
 msgid "Cancel"
 msgstr "Abbrechen"
 
 #. IndicatorItem switch_user_menu = new IndicatorItem(_("Switch User"),
 #. "network-transmit-receive-symbolic", false);
-#: ../daemon/endsession.ui.h:4
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:179
+#: ../src/daemon/endsession.ui.h:4
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:179
 msgid "Logout"
 msgstr "Abmelden"
 
-#: ../daemon/endsession.ui.h:5
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:104
+#: ../src/daemon/endsession.ui.h:5
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:104
 msgid "Restart"
 msgstr "Neustarten"
 
-#: ../daemon/endsession.ui.h:6
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:105
+#: ../src/daemon/endsession.ui.h:6
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:105
 msgid "Shutdown"
 msgstr "Herunterfahren"
 
-#: ../panel/applets/clock/ClockApplet.vala:55
+#: ../src/panel/applets/clock/ClockApplet.vala:55
 msgid "Time and date settings"
 msgstr "Zeit- und Datumseinstellungen"
 
-#: ../panel/applets/clock/ClockApplet.vala:56
+#: ../src/panel/applets/clock/ClockApplet.vala:56
 msgid "Calendar"
 msgstr "Kalender"
 
-#: ../panel/applets/icon-tasklist/Buttons.vala:90
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:90
 msgid "Pin to panel"
 msgstr "An Leiste anheften"
 
-#: ../panel/applets/icon-tasklist/Buttons.vala:91
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:91
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:455
 msgid "Unpin from panel"
 msgstr "Von Leiste lösen"
 
 #. Special case, "All"
-#: ../panel/applets/budgie-menu/BudgieMenuWindow.vala:31
+#: ../src/panel/applets/budgie-menu/BudgieMenuWindow.vala:31
 msgid "All"
 msgstr "Alle"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:53
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:53
 msgid "Caps lock is active"
 msgstr "Feststelltaste ist aktiv"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:56
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:56
 msgid "Caps lock is not active"
 msgstr "Feststelltaste ist inaktiv"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:66
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:66
 msgid "Num lock is active"
 msgstr "Num-Lock-Taste ist aktiv"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:69
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:69
 msgid "Num lock is not active"
 msgstr "Num-Lock-Taste ist nicht aktiv"
 
-#: ../panel/applets/show-desktop/ShowDesktopApplet.vala:33
+#: ../src/panel/applets/show-desktop/ShowDesktopApplet.vala:33
 msgid "Toggle the desktop"
 msgstr "Desktops umschalten"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:101
+#: ../src/panel/applets/status/BluetoothIndicator.vala:101
 msgid "Bluetooth is disabled"
 msgstr "Bluetooth ist deaktiviert"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:105
+#: ../src/panel/applets/status/BluetoothIndicator.vala:105
 msgid "Bluetooth is active"
 msgstr "Bluetooth ist aktiviert"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:110
+#: ../src/panel/applets/status/BluetoothIndicator.vala:110
 #, c-format
 msgid "Connected to %d device"
 msgid_plural "Connected to %d devices"
 msgstr[0] "Verbunden mit %d Gerät"
 msgstr[1] "Verbunden mit %d Geräten"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:171
+#: ../src/panel/applets/status/BluetoothIndicator.vala:171
 msgid "Bluetooth Settings"
 msgstr "Bluetooth-Einstellungen"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:172
+#: ../src/panel/applets/status/BluetoothIndicator.vala:172
 msgid "Send Files"
 msgstr "Dateien senden"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:173
+#: ../src/panel/applets/status/BluetoothIndicator.vala:173
 msgid "Bluetooth Airplane Mode"
 msgstr "Bluetooth-Flugzeugmodus"
 
-#: ../panel/applets/status/PowerIndicator.vala:56
+#: ../src/panel/applets/status/PowerIndicator.vala:56
 msgid "Battery fully charged."
 msgstr "Akku vollständig aufgeladen."
 
-#: ../panel/applets/status/PowerIndicator.vala:59
+#: ../src/panel/applets/status/PowerIndicator.vala:59
 msgid "Unknown"
 msgstr "Unbekannt"
 
 #. Set inner charging duration to hours:minutes
-#: ../panel/applets/status/PowerIndicator.vala:68
+#: ../src/panel/applets/status/PowerIndicator.vala:68
 msgid "Battery charging"
 msgstr "Akku wird aufgeladen"
 
-#: ../panel/applets/status/PowerIndicator.vala:73
+#: ../src/panel/applets/status/PowerIndicator.vala:73
 msgid "Battery remaining"
 msgstr "Akku verbleiben"
 
-#: ../panel/applets/status/PowerIndicator.vala:107
+#: ../src/panel/applets/status/PowerIndicator.vala:107
 msgid "Power settings"
 msgstr "Energieeinstellungen"
 
 #. User Menu Creation
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:95
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:95
 msgid "User"
 msgstr "Benutzer"
 
 #. Default to "User" and symbolic icon
 #. The rest
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:101
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:101
 msgid "Lock"
 msgstr "Sperren"
 
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:102
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:102
 msgid "Suspend"
 msgstr "Bereitschaftszustand"
 
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:103
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:103
 msgid "Hibernate"
 msgstr "Ruhezustand"
 
-#: ../wm/windowmenu.vala:124
+#: ../src/wm/windowmenu.vala:124
 msgid "Minimize"
 msgstr "Minimieren"
 
-#: ../wm/windowmenu.vala:129
+#: ../src/wm/windowmenu.vala:129
 msgid "Unmaximize"
 msgstr "Größe wiederherstellen"
 
-#: ../wm/windowmenu.vala:134
+#: ../src/wm/windowmenu.vala:134
 msgid "Maximize"
 msgstr "Maximieren"
 
-#: ../wm/windowmenu.vala:139
+#: ../src/wm/windowmenu.vala:139
 msgid "Move"
 msgstr "Bewegen"
 
-#: ../wm/windowmenu.vala:144
+#: ../src/wm/windowmenu.vala:144
 msgid "Resize"
 msgstr "Größe anpassen"
 
-#: ../wm/windowmenu.vala:149
+#: ../src/wm/windowmenu.vala:149
 msgid "Always On Top"
 msgstr "Immer im Vordergrund"
 
-#: ../wm/windowmenu.vala:154
+#: ../src/wm/windowmenu.vala:154
 msgid "Close"
 msgstr "Schließen"
 
-#: ../wm/wm.vala:515
+#: ../src/wm/wm.vala:519
 msgid "Change background"
 msgstr "Hintergrund ändern"
 
-#: ../wm/wm.vala:524
+#: ../src/wm/wm.vala:528
 msgid "Settings"
 msgstr "Einstellungen"
 
+#. End BudgieWMDBUS
 #. End namespace
 #. * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
 #. *
@@ -463,119 +468,137 @@ msgstr "Einstellungen"
 #. *
 #. * vi: set shiftwidth=4 tabstop=4 expandtab:
 #. * :indentSize=4:tabSize=4:noTabs=true:
-#: ../panel/applets/clock/ClockApplet.plugin.in.h:1
+#: ../src/panel/applets/clock/ClockApplet.plugin.in.h:1
 msgid "Clock"
 msgstr "Uhr"
 
-#: ../panel/applets/show-desktop/ShowDesktopApplet.plugin.in.h:1
+#: ../src/panel/applets/show-desktop/ShowDesktopApplet.plugin.in.h:1
 msgid "Show Desktop Button"
 msgstr "Desktop anzeigen"
 
-#: ../panel/applets/tasklist/TasklistApplet.plugin.in.h:1
+#: ../src/panel/applets/tasklist/TasklistApplet.plugin.in.h:1
 msgid "Task List"
 msgstr "Task Liste"
 
-#: ../panel/applets/icon-tasklist/IconTasklistApplet.plugin.in.h:1
+#: ../src/panel/applets/places-indicator/PlacesIndicator.plugin.in.h:1
+#: ../src/panel/applets/places-indicator/PlacesIndicator.vala:80
+#: ../src/panel/applets/places-indicator/PlacesSection.vala:32
+msgid "Places"
+msgstr "Orte"
+
+#: ../src/panel/applets/icon-tasklist/IconTasklistApplet.plugin.in.h:1
 msgid "Icon Task List"
 msgstr "App-Leiste"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.plugin.in.h:1
+#: ../src/panel/applets/lock-keys/LockKeysApplet.plugin.in.h:1
 msgid "Lock Keys Indicator"
 msgstr "Tastensperreanzeige"
 
-#: ../panel/applets/spacer/SpacerApplet.plugin.in.h:1
+#: ../src/panel/applets/raven-trigger/RavenTriggerApplet.plugin.in.h:1
+msgid "Raven Sidebar Control"
+msgstr "Raven Steuerungsleiste"
+
+#: ../src/panel/applets/spacer/SpacerApplet.plugin.in.h:1
 msgid "Spacer"
 msgstr "Platzhalter"
 
-#: ../panel/applets/workspaces/WorkspacesApplet.plugin.in.h:1
+#: ../src/panel/applets/user-indicator/UserIndicator.plugin.in.h:1
+msgid "User Indicator"
+msgstr "Benutzeranzeige"
+
+#: ../src/panel/applets/workspaces/WorkspacesApplet.plugin.in.h:1
 msgid "Workspace Switcher"
 msgstr "Arbeitsflächenumschalter"
 
-#: ../panel/applets/tray/TrayApplet.plugin.in.h:1
+#: ../src/panel/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in.h:1
+msgid "Keyboard Layout Indicator"
+msgstr "Tastaturlayout-Anzeige"
+
+#: ../src/panel/applets/tray/TrayApplet.plugin.in.h:1
 msgid "System Tray"
 msgstr "Systemleiste"
 
-#: ../panel/applets/status/StatusApplet.plugin.in.h:1
+#: ../src/panel/applets/status/StatusApplet.plugin.in.h:1
 msgid "Status Indicator"
 msgstr "Statusanzeige"
 
-#: ../panel/applets/budgie-menu/BudgieMenu.plugin.in.h:1
+#: ../src/panel/applets/budgie-menu/BudgieMenu.plugin.in.h:1
 msgid "Budgie Menu"
 msgstr "Budgie Menü"
 
-#: ../panel/applets/separator/SeparatorApplet.plugin.in.h:1
+#: ../src/panel/applets/separator/SeparatorApplet.plugin.in.h:1
 msgid "Separator"
 msgstr "Trennlinie"
 
-#: ../panel/applets/places-indicator/MountItem.vala:23
-#: ../panel/applets/places-indicator/VolumeItem.vala:23
+#: ../src/panel/applets/places-indicator/MountItem.vala:23
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:23
 msgid "Removable devices"
 msgstr "Entfernbare Geräte"
 
-#: ../panel/applets/places-indicator/MountItem.vala:25
-#: ../panel/applets/places-indicator/VolumeItem.vala:25
+#: ../src/panel/applets/places-indicator/MountItem.vala:25
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:25
 msgid "Local volumes"
-msgstr ""
+msgstr "Lokale Datenträger"
 
-#: ../panel/applets/places-indicator/MountItem.vala:29
-#: ../panel/applets/places-indicator/VolumeItem.vala:29
+#: ../src/panel/applets/places-indicator/MountItem.vala:29
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:29
 msgid "Network folders"
 msgstr "Netzwerkordner"
 
-#: ../panel/applets/places-indicator/MountItem.vala:49
-#: ../panel/applets/places-indicator/VolumeItem.vala:46
+#: ../src/panel/applets/places-indicator/MountItem.vala:32
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:32
+msgid "Other"
+msgstr "Weitere"
+
+#: ../src/panel/applets/places-indicator/MountItem.vala:52
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:49
 msgid "Eject"
 msgstr "Auswerfen"
 
-#: ../panel/applets/places-indicator/MountItem.vala:51
+#: ../src/panel/applets/places-indicator/MountItem.vala:54
 msgid "Unmount"
 msgstr "Aushängen"
 
-#: ../panel/applets/places-indicator/MountItem.vala:54
-#: ../panel/applets/places-indicator/PlaceItem.vala:27
+#: ../src/panel/applets/places-indicator/MountItem.vala:57
+#: ../src/panel/applets/places-indicator/PlaceItem.vala:27
 #, c-format
 msgid "Open \"%s\""
 msgstr "\"%s\" öffnen"
 
-#: ../panel/applets/places-indicator/MountItem.vala:78
-#: ../panel/applets/places-indicator/VolumeItem.vala:53
+#: ../src/panel/applets/places-indicator/MountItem.vala:81
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:56
 msgid "You can now safely remove"
 msgstr "Sie können nun sicher entfernen"
 
-#: ../panel/applets/places-indicator/PlacesIndicator.vala:80
-#: ../panel/applets/places-indicator/PlacesSection.vala:32
-msgid "Places"
-msgstr ""
-
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:139
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:139
 msgid "Nothing to display right now"
-msgstr ""
+msgstr "Es kann nichts angezeigt werden"
 
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Mount some drives"
-msgstr ""
+msgstr "Laufwerke einhängen"
 
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Enable more sections"
-msgstr ""
+msgstr "Mehr Unterteilungen anzeigen"
 
-#: ../panel/applets/places-indicator/VolumeItem.vala:64
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:67
 #, c-format
 msgid "Mount and open \"%s\""
 msgstr "\"%s\" einhängen und öffnen"
 
-#: ../panel/applets/places-indicator/settings.ui.h:1
+#: ../src/panel/applets/places-indicator/settings.ui.h:1
 msgid "Show label"
 msgstr "Bezeichnung anzeigen"
 
-#: ../panel/applets/places-indicator/settings.ui.h:2
+#: ../src/panel/applets/places-indicator/settings.ui.h:2
 msgid "Show places"
-msgstr ""
+msgstr "Orte anzeigen"
 
-#: ../panel/applets/places-indicator/settings.ui.h:3
+#: ../src/panel/applets/places-indicator/settings.ui.h:3
 msgid "Show removable drives"
-msgstr "Entfernbare Laufwerke anzeigen"
+msgstr "Wechseldatenträger anzeigen"
 
-#: ../panel/applets/places-indicator/settings.ui.h:4
+#: ../src/panel/applets/places-indicator/settings.ui.h:4
 msgid "Show network folders"
 msgstr "Netzwerkordner anzeigen"

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -7,132 +7,133 @@
 # Federico Damián Schonborn <federicodamians@gmail.com>, 2016
 # Federico Damián Schonborn <federico.d.schonborn@gmail.com>, 2016
 # Federico Damián Schonborn <federicodamians@gmail.com>, 2015-2016
+# iachopolo <iapolo.90@gmail.com>, 2017
 # Karus Insania <karusinsania@gmail.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Budgie Desktop\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-21 08:11+0100\n"
-"PO-Revision-Date: 2016-10-21 14:31+0000\n"
-"Last-Translator: Federico Damián Schonborn <federico.d.schonborn@gmail.com>\n"
-"Language-Team: Spanish (Argentina) (http://www.transifex.com/solus-project/budgie-desktop/language/es_AR/)\n"
+"POT-Creation-Date: 2016-10-26 04:02+0100\n"
+"PO-Revision-Date: 2017-03-26 15:21+0000\n"
+"Last-Translator: iachopolo <iapolo.90@gmail.com>\n"
+"Language-Team: Spanish (Argentina) (http://www.transifex.com/budgie-desktop/budgie-desktop/language/es_AR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: es_AR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../daemon/endsession.vala:167
+#: ../src/daemon/endsession.vala:167
 msgid "Log out"
 msgstr "Cerrar sesión"
 
-#: ../daemon/endsession.vala:171
+#: ../src/daemon/endsession.vala:171
 msgid "Restart device"
 msgstr "Reiniciar dispositivo"
 
-#: ../daemon/endsession.vala:183 ../daemon/endsession.ui.h:1
+#: ../src/daemon/endsession.vala:183 ../src/daemon/endsession.ui.h:1
 msgid "Power Off"
 msgstr "Apagar"
 
-#: ../raven/main_view.vala:72 ../raven/ui/panel.ui.h:7
+#: ../src/raven/main_view.vala:72 ../src/raven/ui/panel.ui.h:7
 msgid "Applets"
 msgstr "Componentes"
 
-#: ../raven/main_view.vala:75
-#: ../panel/applets/notifications/NotificationsApplet.plugin.in.h:1
+#: ../src/raven/main_view.vala:75
+#: ../src/panel/applets/notifications/NotificationsApplet.plugin.in.h:1
 msgid "Notifications"
 msgstr "Notificaciones"
 
-#: ../raven/settings_view.vala:266
+#: ../src/raven/settings_view.vala:266
 msgid "Top"
 msgstr "Arriba"
 
-#: ../raven/settings_view.vala:268
+#: ../src/raven/settings_view.vala:268
 msgid "Bottom"
 msgstr "Abajo"
 
-#: ../raven/settings_view.vala:376
+#: ../src/raven/settings_view.vala:376
 msgid "Top Panel"
 msgstr "Panel superior"
 
-#: ../raven/settings_view.vala:378
+#: ../src/raven/settings_view.vala:378
 msgid "Right Panel"
 msgstr "Panel derecho"
 
-#: ../raven/settings_view.vala:380
+#: ../src/raven/settings_view.vala:380
 msgid "Left Panel"
 msgstr "Panel izquierdo"
 
-#: ../raven/settings_view.vala:382
+#: ../src/raven/settings_view.vala:382
 msgid "Bottom Panel"
 msgstr "Panel inferior"
 
-#: ../raven/settings_view.vala:616
+#: ../src/raven/settings_view.vala:616
 msgid "Start"
 msgstr "Inicio"
 
-#: ../raven/settings_view.vala:619
+#: ../src/raven/settings_view.vala:619
 msgid "Center"
 msgstr "Centro"
 
-#: ../raven/settings_view.vala:622
+#: ../src/raven/settings_view.vala:622
 msgid "End"
 msgstr "Fin"
 
 #. Appearance expander
-#: ../raven/settings_view.vala:960
+#: ../src/raven/settings_view.vala:960
 msgid "Appearance"
 msgstr "Apariencia"
 
-#: ../raven/settings_view.vala:967
+#: ../src/raven/settings_view.vala:967
 msgid "Background"
 msgstr "Fondo"
 
-#: ../raven/settings_view.vala:974
+#: ../src/raven/settings_view.vala:974
 msgid "Fonts"
 msgstr "Fuentes"
 
-#: ../raven/settings_view.vala:980
+#: ../src/raven/settings_view.vala:980
 msgid "Windows"
 msgstr "Ventanas"
 
-#: ../raven/settings_view.vala:984
+#: ../src/raven/settings_view.vala:984
 msgid "General"
 msgstr "General"
 
-#: ../raven/settings_view.vala:995 ../raven/settings_view.vala:996
+#: ../src/raven/settings_view.vala:995 ../src/raven/settings_view.vala:996
 msgid "Panel"
 msgstr "Panel"
 
-#: ../raven/notifications_view.vala:74
+#: ../src/raven/notifications_view.vala:74
 msgid "Nothing to see here"
 msgstr "Nada que ver aquí"
 
-#: ../raven/notifications_view.vala:516
-#: ../panel/applets/notifications/NotificationsApplet.vala:75
+#: ../src/raven/notifications_view.vala:516
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:75
 #, c-format
 msgid "%u unread notifications"
 msgstr "%u notificaciones sin leer"
 
-#: ../raven/notifications_view.vala:518
-#: ../panel/applets/notifications/NotificationsApplet.vala:77
+#: ../src/raven/notifications_view.vala:518
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:77
 msgid "1 unread notification"
 msgstr "1 notificación sin leer"
 
-#: ../raven/notifications_view.vala:520
-#: ../panel/applets/notifications/NotificationsApplet.vala:79
+#: ../src/raven/notifications_view.vala:520
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:79
 msgid "No unread notifications"
 msgstr "No hay notificaciones sin leer"
 
-#: ../raven/notifications_view.vala:646
+#: ../src/raven/notifications_view.vala:646
 msgid "No new notifications"
 msgstr "No hay nuevas notificaciones"
 
-#: ../raven/sound.vala:78
+#: ../src/raven/sound.vala:78
 msgid "Output"
 msgstr "Salida"
 
-#: ../raven/sound.vala:95
+#: ../src/raven/sound.vala:95
 msgid "Input"
 msgstr "Entrada"
 
@@ -147,301 +148,302 @@ msgstr "Entrada"
 #. *
 #. * vi: set shiftwidth=4 tabstop=4 expandtab:
 #. * :indentSize=4:tabSize=4:noTabs=true:
-#: ../panel/applets/spacer/settings.ui.h:1
+#: ../src/panel/applets/spacer/settings.ui.h:1
 msgid "Spacer size"
 msgstr "Tamaño del espaciador"
 
-#: ../raven/ui/settings.ui.h:1
+#: ../src/raven/ui/settings.ui.h:1
 msgid "Budgie Settings"
 msgstr "Ajustes"
 
-#: ../raven/ui/settings.ui.h:2
+#: ../src/raven/ui/settings.ui.h:2
 msgid "Exit"
 msgstr "Salir"
 
-#: ../raven/ui/applets.ui.h:1
+#: ../src/raven/ui/applets.ui.h:1
 msgid "Add new applet"
 msgstr "Añadir componente"
 
-#: ../raven/ui/appearance.ui.h:1
+#: ../src/raven/ui/appearance.ui.h:1
 msgid "Use the dark theme"
 msgstr "Usar el tema oscuro"
 
-#: ../raven/ui/appearance.ui.h:2
+#: ../src/raven/ui/appearance.ui.h:2
 msgid "Dark theme"
 msgstr "Tema oscuro"
 
-#: ../raven/ui/appearance.ui.h:3
+#: ../src/raven/ui/appearance.ui.h:3
 msgid "Select a GTK+ theme"
 msgstr "Selecciona un tema GTK+"
 
-#: ../raven/ui/appearance.ui.h:4
+#: ../src/raven/ui/appearance.ui.h:4
 msgid "Widget Theme"
 msgstr "Tema GTK+"
 
-#: ../raven/ui/appearance.ui.h:5
+#: ../src/raven/ui/appearance.ui.h:5
 msgid "Select an icon theme"
 msgstr "Selecciona un tema de iconos"
 
-#: ../raven/ui/appearance.ui.h:6
+#: ../src/raven/ui/appearance.ui.h:6
 msgid "Icon Theme"
 msgstr "Tema de iconos"
 
-#: ../raven/ui/appearance.ui.h:7
+#: ../src/raven/ui/appearance.ui.h:7
 msgid "Override defaults"
 msgstr "Anular tema por defecto"
 
-#: ../raven/ui/appearance.ui.h:8
+#: ../src/raven/ui/appearance.ui.h:8
 msgid "Built-in theme"
 msgstr "Tema incorporado"
 
-#: ../raven/ui/appearance.ui.h:9
+#: ../src/raven/ui/appearance.ui.h:9
 msgid "Select a cursor theme"
 msgstr "Selecciona un tema de cursor"
 
-#: ../raven/ui/appearance.ui.h:10
+#: ../src/raven/ui/appearance.ui.h:10
 msgid "Cursor Theme"
 msgstr "Tema de cursor"
 
-#: ../raven/ui/panel.ui.h:1
+#: ../src/raven/ui/panel.ui.h:1
 msgid "Manage Panels"
 msgstr "Gestionar paneles"
 
-#: ../raven/ui/panel.ui.h:2
+#: ../src/raven/ui/panel.ui.h:2
 msgid "Position"
 msgstr "Posición"
 
-#: ../raven/ui/panel.ui.h:3
+#: ../src/raven/ui/panel.ui.h:3
 msgid "Size"
 msgstr "Tamaño"
 
-#: ../raven/ui/panel.ui.h:4
+#: ../src/raven/ui/panel.ui.h:4
 msgid "Shadow"
 msgstr "Sombra"
 
-#: ../raven/ui/panel.ui.h:5
+#: ../src/raven/ui/panel.ui.h:5
 msgid "Autohide policy"
 msgstr "Política de auto-ocultado"
 
-#: ../raven/ui/panel.ui.h:6
+#: ../src/raven/ui/panel.ui.h:6
 msgid "Stylize regions"
 msgstr "Región estilizada"
 
-#: ../raven/ui/background.ui.h:1
+#: ../src/raven/ui/background.ui.h:1
 msgid "Show desktop icons"
 msgstr "Mostrar iconos en el escritorio"
 
-#: ../raven/ui/background.ui.h:2
+#: ../src/raven/ui/background.ui.h:2
 msgid "Desktop Icons"
 msgstr "Iconos en el escritorio"
 
-#: ../raven/ui/fonts.ui.h:1
+#: ../src/raven/ui/fonts.ui.h:1
 msgid "Window Titles"
 msgstr "Títulos de ventana"
 
-#: ../raven/ui/fonts.ui.h:2
+#: ../src/raven/ui/fonts.ui.h:2
 msgid "Interface"
 msgstr "Interfaz"
 
-#: ../raven/ui/fonts.ui.h:3
+#: ../src/raven/ui/fonts.ui.h:3
 msgid "Documents"
 msgstr "Documentos"
 
-#: ../raven/ui/fonts.ui.h:4
+#: ../src/raven/ui/fonts.ui.h:4
 msgid "Monospace"
 msgstr "Monoespacio"
 
-#: ../raven/ui/wm.ui.h:1
+#: ../src/raven/ui/wm.ui.h:1
 msgid "Disable unredirect of fullscreen windows"
 msgstr "Redirección de ventanas en pantalla completa"
 
-#: ../raven/ui/wm.ui.h:2
+#: ../src/raven/ui/wm.ui.h:2
 msgid "Disable unredirect"
 msgstr "Habilitar redirección"
 
-#: ../raven/ui/wm.ui.h:3
+#: ../src/raven/ui/wm.ui.h:3
 msgid "Change the layout of the window buttons"
 msgstr "Cambiar la disposición de los botones de ventana"
 
-#: ../raven/ui/wm.ui.h:4
+#: ../src/raven/ui/wm.ui.h:4
 msgid "Button layout"
 msgstr "Disposición de los botones"
 
-#: ../session/budgie-desktop.desktop.in.in.h:1
-#: ../session/budgie-desktop.session.in.in.h:1
+#: ../src/session/budgie-desktop.desktop.in.in.h:1
+#: ../src/session/budgie-desktop.session.in.in.h:1
 msgid "Budgie Desktop"
 msgstr "Escritorio Budgie"
 
-#: ../session/budgie-desktop.desktop.in.in.h:2
+#: ../src/session/budgie-desktop.desktop.in.in.h:2
 msgid "This session logs you into the Budgie Desktop"
-msgstr "Esta sesión te logueará en el Escritorio Budgie"
+msgstr "Esta sesión se iniciará en el Escritorio Budgie"
 
-#: ../daemon/endsession.ui.h:2
+#: ../src/daemon/endsession.ui.h:2
 msgid "Are you sure you want to end your session?"
 msgstr "¿Estás seguro de que quieres terminar la sesión?"
 
-#: ../daemon/endsession.ui.h:3
+#: ../src/daemon/endsession.ui.h:3
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. IndicatorItem switch_user_menu = new IndicatorItem(_("Switch User"),
 #. "network-transmit-receive-symbolic", false);
-#: ../daemon/endsession.ui.h:4
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:179
+#: ../src/daemon/endsession.ui.h:4
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:179
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#: ../daemon/endsession.ui.h:5
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:104
+#: ../src/daemon/endsession.ui.h:5
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:104
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: ../daemon/endsession.ui.h:6
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:105
+#: ../src/daemon/endsession.ui.h:6
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:105
 msgid "Shutdown"
 msgstr "Apagar"
 
-#: ../panel/applets/clock/ClockApplet.vala:55
+#: ../src/panel/applets/clock/ClockApplet.vala:55
 msgid "Time and date settings"
 msgstr "Ajustes de fecha y hora"
 
-#: ../panel/applets/clock/ClockApplet.vala:56
+#: ../src/panel/applets/clock/ClockApplet.vala:56
 msgid "Calendar"
 msgstr "Calendario"
 
-#: ../panel/applets/icon-tasklist/Buttons.vala:90
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:90
 msgid "Pin to panel"
 msgstr "Añadir al panel"
 
-#: ../panel/applets/icon-tasklist/Buttons.vala:91
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:91
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:455
 msgid "Unpin from panel"
 msgstr "Quitar del panel"
 
 #. Special case, "All"
-#: ../panel/applets/budgie-menu/BudgieMenuWindow.vala:31
+#: ../src/panel/applets/budgie-menu/BudgieMenuWindow.vala:31
 msgid "All"
 msgstr "Todo"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:53
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:53
 msgid "Caps lock is active"
 msgstr "Bloq. Mayús. está activado"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:56
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:56
 msgid "Caps lock is not active"
 msgstr "Bloq. Mayús. está desactivado"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:66
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:66
 msgid "Num lock is active"
 msgstr "Bloq. Núm. está activado"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:69
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:69
 msgid "Num lock is not active"
 msgstr "Bloq. Núm. está desactivado"
 
-#: ../panel/applets/show-desktop/ShowDesktopApplet.vala:33
+#: ../src/panel/applets/show-desktop/ShowDesktopApplet.vala:33
 msgid "Toggle the desktop"
 msgstr "Alternar el escritorio"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:101
+#: ../src/panel/applets/status/BluetoothIndicator.vala:101
 msgid "Bluetooth is disabled"
 msgstr "Bluetooth está activo"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:105
+#: ../src/panel/applets/status/BluetoothIndicator.vala:105
 msgid "Bluetooth is active"
 msgstr "Bluetooth está inactivo"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:110
+#: ../src/panel/applets/status/BluetoothIndicator.vala:110
 #, c-format
 msgid "Connected to %d device"
 msgid_plural "Connected to %d devices"
 msgstr[0] "Conectado a %d dispositivo"
 msgstr[1] "Conectado a %d dispositivos"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:171
+#: ../src/panel/applets/status/BluetoothIndicator.vala:171
 msgid "Bluetooth Settings"
 msgstr "Ajustes de Bluetooth"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:172
+#: ../src/panel/applets/status/BluetoothIndicator.vala:172
 msgid "Send Files"
 msgstr "Enviar archivos"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:173
+#: ../src/panel/applets/status/BluetoothIndicator.vala:173
 msgid "Bluetooth Airplane Mode"
 msgstr "Bluetooth Modo Avión"
 
-#: ../panel/applets/status/PowerIndicator.vala:56
+#: ../src/panel/applets/status/PowerIndicator.vala:56
 msgid "Battery fully charged."
 msgstr "Batería completamente cargada."
 
-#: ../panel/applets/status/PowerIndicator.vala:59
+#: ../src/panel/applets/status/PowerIndicator.vala:59
 msgid "Unknown"
 msgstr "Desconocido"
 
 #. Set inner charging duration to hours:minutes
-#: ../panel/applets/status/PowerIndicator.vala:68
+#: ../src/panel/applets/status/PowerIndicator.vala:68
 msgid "Battery charging"
 msgstr "Batería cargando"
 
-#: ../panel/applets/status/PowerIndicator.vala:73
+#: ../src/panel/applets/status/PowerIndicator.vala:73
 msgid "Battery remaining"
 msgstr "Batería restante"
 
-#: ../panel/applets/status/PowerIndicator.vala:107
+#: ../src/panel/applets/status/PowerIndicator.vala:107
 msgid "Power settings"
 msgstr "Ajustes de energía"
 
 #. User Menu Creation
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:95
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:95
 msgid "User"
 msgstr "Usuario"
 
 #. Default to "User" and symbolic icon
 #. The rest
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:101
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:101
 msgid "Lock"
 msgstr "Bloquear"
 
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:102
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:102
 msgid "Suspend"
 msgstr "Suspender"
 
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:103
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:103
 msgid "Hibernate"
 msgstr "Hibernar"
 
-#: ../wm/windowmenu.vala:124
+#: ../src/wm/windowmenu.vala:124
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: ../wm/windowmenu.vala:129
+#: ../src/wm/windowmenu.vala:129
 msgid "Unmaximize"
 msgstr "Des-maximizar"
 
-#: ../wm/windowmenu.vala:134
+#: ../src/wm/windowmenu.vala:134
 msgid "Maximize"
 msgstr "Maximizar"
 
-#: ../wm/windowmenu.vala:139
+#: ../src/wm/windowmenu.vala:139
 msgid "Move"
 msgstr "Mover"
 
-#: ../wm/windowmenu.vala:144
+#: ../src/wm/windowmenu.vala:144
 msgid "Resize"
 msgstr "Redimensionar"
 
-#: ../wm/windowmenu.vala:149
+#: ../src/wm/windowmenu.vala:149
 msgid "Always On Top"
 msgstr "Siempre encima"
 
-#: ../wm/windowmenu.vala:154
+#: ../src/wm/windowmenu.vala:154
 msgid "Close"
 msgstr "Cerrar"
 
-#: ../wm/wm.vala:519
+#: ../src/wm/wm.vala:519
 msgid "Change background"
 msgstr "Cambiar el fondo"
 
-#: ../wm/wm.vala:528
+#: ../src/wm/wm.vala:528
 msgid "Settings"
 msgstr "Ajustes"
 
@@ -457,137 +459,137 @@ msgstr "Ajustes"
 #. *
 #. * vi: set shiftwidth=4 tabstop=4 expandtab:
 #. * :indentSize=4:tabSize=4:noTabs=true:
-#: ../panel/applets/clock/ClockApplet.plugin.in.h:1
+#: ../src/panel/applets/clock/ClockApplet.plugin.in.h:1
 msgid "Clock"
 msgstr "Reloj"
 
-#: ../panel/applets/show-desktop/ShowDesktopApplet.plugin.in.h:1
+#: ../src/panel/applets/show-desktop/ShowDesktopApplet.plugin.in.h:1
 msgid "Show Desktop Button"
 msgstr "Mostrar/ocultar escritorio"
 
-#: ../panel/applets/tasklist/TasklistApplet.plugin.in.h:1
+#: ../src/panel/applets/tasklist/TasklistApplet.plugin.in.h:1
 msgid "Task List"
 msgstr "Gestor de tareas"
 
-#: ../panel/applets/places-indicator/PlacesIndicator.plugin.in.h:1
-#: ../panel/applets/places-indicator/PlacesIndicator.vala:80
-#: ../panel/applets/places-indicator/PlacesSection.vala:32
+#: ../src/panel/applets/places-indicator/PlacesIndicator.plugin.in.h:1
+#: ../src/panel/applets/places-indicator/PlacesIndicator.vala:80
+#: ../src/panel/applets/places-indicator/PlacesSection.vala:32
 msgid "Places"
 msgstr "Lugares"
 
-#: ../panel/applets/icon-tasklist/IconTasklistApplet.plugin.in.h:1
+#: ../src/panel/applets/icon-tasklist/IconTasklistApplet.plugin.in.h:1
 msgid "Icon Task List"
 msgstr "Gestor de tareas de solo iconos"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.plugin.in.h:1
+#: ../src/panel/applets/lock-keys/LockKeysApplet.plugin.in.h:1
 msgid "Lock Keys Indicator"
 msgstr "Indicador de teclas de bloqueo"
 
-#: ../panel/applets/raven-trigger/RavenTriggerApplet.plugin.in.h:1
+#: ../src/panel/applets/raven-trigger/RavenTriggerApplet.plugin.in.h:1
 msgid "Raven Sidebar Control"
 msgstr "Control de barra lateral Raven"
 
-#: ../panel/applets/spacer/SpacerApplet.plugin.in.h:1
+#: ../src/panel/applets/spacer/SpacerApplet.plugin.in.h:1
 msgid "Spacer"
 msgstr "Espaciador"
 
-#: ../panel/applets/user-indicator/UserIndicator.plugin.in.h:1
+#: ../src/panel/applets/user-indicator/UserIndicator.plugin.in.h:1
 msgid "User Indicator"
 msgstr "Indicador de usuario"
 
-#: ../panel/applets/workspaces/WorkspacesApplet.plugin.in.h:1
+#: ../src/panel/applets/workspaces/WorkspacesApplet.plugin.in.h:1
 msgid "Workspace Switcher"
 msgstr "Selector de escritorio"
 
-#: ../panel/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in.h:1
+#: ../src/panel/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in.h:1
 msgid "Keyboard Layout Indicator"
 msgstr "Indicador de disposición del teclado"
 
-#: ../panel/applets/tray/TrayApplet.plugin.in.h:1
+#: ../src/panel/applets/tray/TrayApplet.plugin.in.h:1
 msgid "System Tray"
 msgstr "Bandeja del sistema"
 
-#: ../panel/applets/status/StatusApplet.plugin.in.h:1
+#: ../src/panel/applets/status/StatusApplet.plugin.in.h:1
 msgid "Status Indicator"
 msgstr "Indicador de estado"
 
-#: ../panel/applets/budgie-menu/BudgieMenu.plugin.in.h:1
+#: ../src/panel/applets/budgie-menu/BudgieMenu.plugin.in.h:1
 msgid "Budgie Menu"
 msgstr "Menú"
 
-#: ../panel/applets/separator/SeparatorApplet.plugin.in.h:1
+#: ../src/panel/applets/separator/SeparatorApplet.plugin.in.h:1
 msgid "Separator"
 msgstr "Separador"
 
-#: ../panel/applets/places-indicator/MountItem.vala:23
-#: ../panel/applets/places-indicator/VolumeItem.vala:23
+#: ../src/panel/applets/places-indicator/MountItem.vala:23
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:23
 msgid "Removable devices"
 msgstr "Dispositivos removibles"
 
-#: ../panel/applets/places-indicator/MountItem.vala:25
-#: ../panel/applets/places-indicator/VolumeItem.vala:25
+#: ../src/panel/applets/places-indicator/MountItem.vala:25
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:25
 msgid "Local volumes"
 msgstr "Dispositivos locales"
 
-#: ../panel/applets/places-indicator/MountItem.vala:29
-#: ../panel/applets/places-indicator/VolumeItem.vala:29
+#: ../src/panel/applets/places-indicator/MountItem.vala:29
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:29
 msgid "Network folders"
 msgstr "Carpetas en red"
 
-#: ../panel/applets/places-indicator/MountItem.vala:32
-#: ../panel/applets/places-indicator/VolumeItem.vala:32
+#: ../src/panel/applets/places-indicator/MountItem.vala:32
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:32
 msgid "Other"
 msgstr "Otros"
 
-#: ../panel/applets/places-indicator/MountItem.vala:52
-#: ../panel/applets/places-indicator/VolumeItem.vala:49
+#: ../src/panel/applets/places-indicator/MountItem.vala:52
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:49
 msgid "Eject"
 msgstr "Expulsar"
 
-#: ../panel/applets/places-indicator/MountItem.vala:54
+#: ../src/panel/applets/places-indicator/MountItem.vala:54
 msgid "Unmount"
 msgstr "Desmontar"
 
-#: ../panel/applets/places-indicator/MountItem.vala:57
-#: ../panel/applets/places-indicator/PlaceItem.vala:27
+#: ../src/panel/applets/places-indicator/MountItem.vala:57
+#: ../src/panel/applets/places-indicator/PlaceItem.vala:27
 #, c-format
 msgid "Open \"%s\""
 msgstr "Abrir \"%s\""
 
-#: ../panel/applets/places-indicator/MountItem.vala:81
-#: ../panel/applets/places-indicator/VolumeItem.vala:56
+#: ../src/panel/applets/places-indicator/MountItem.vala:81
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:56
 msgid "You can now safely remove"
 msgstr "Ahora puedes removerlo de forma segura"
 
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:139
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:139
 msgid "Nothing to display right now"
 msgstr "Nada que mostrar ahora"
 
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Mount some drives"
 msgstr "Montar algunos discos"
 
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Enable more sections"
 msgstr "Habilitar más secciones"
 
-#: ../panel/applets/places-indicator/VolumeItem.vala:67
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:67
 #, c-format
 msgid "Mount and open \"%s\""
 msgstr "Montar y abrir \"%s\""
 
-#: ../panel/applets/places-indicator/settings.ui.h:1
+#: ../src/panel/applets/places-indicator/settings.ui.h:1
 msgid "Show label"
 msgstr "Mostrar nombre"
 
-#: ../panel/applets/places-indicator/settings.ui.h:2
+#: ../src/panel/applets/places-indicator/settings.ui.h:2
 msgid "Show places"
 msgstr "Mostrar lugares"
 
-#: ../panel/applets/places-indicator/settings.ui.h:3
+#: ../src/panel/applets/places-indicator/settings.ui.h:3
 msgid "Show removable drives"
 msgstr "Mostrar dispositivos removibles"
 
-#: ../panel/applets/places-indicator/settings.ui.h:4
+#: ../src/panel/applets/places-indicator/settings.ui.h:4
 msgid "Show network folders"
 msgstr "Mostrar carpetas en red"

--- a/po/gl.po
+++ b/po/gl.po
@@ -3,35 +3,33 @@
 # This file is distributed under the same license as the PACKAGE package.
 # 
 # Translators:
-# Johan Møller Borgstrøm <johan.budh@gmail.com>, 2015
-# Kris Thomsen <lakristho@gmail.com>, 2015-2016
-# scootergrisen, 2017
-# Thorbjørn Erik Køppen Christensen <awwkaw@gmail.com>, 2017
+# Alfonso Rodríguez <eu.castelos@gmail.com>, 2017
+# Xosé Duncan <xoseduncan@gmail.com>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Budgie Desktop\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-26 04:02+0100\n"
-"PO-Revision-Date: 2017-04-14 19:06+0000\n"
-"Last-Translator: scootergrisen\n"
-"Language-Team: Danish (http://www.transifex.com/budgie-desktop/budgie-desktop/language/da/)\n"
+"PO-Revision-Date: 2017-02-12 20:19+0000\n"
+"Last-Translator: Xosé Duncan <xoseduncan@gmail.com>\n"
+"Language-Team: Galician (http://www.transifex.com/budgie-desktop/budgie-desktop/language/gl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: da\n"
+"Language: gl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../src/daemon/endsession.vala:167
 msgid "Log out"
-msgstr "Log ud"
+msgstr "Pechar sesión"
 
 #: ../src/daemon/endsession.vala:171
 msgid "Restart device"
-msgstr "Genstart enhed"
+msgstr "Reiniciar"
 
 #: ../src/daemon/endsession.vala:183 ../src/daemon/endsession.ui.h:1
 msgid "Power Off"
-msgstr "Sluk"
+msgstr "Apagar"
 
 #: ../src/raven/main_view.vala:72 ../src/raven/ui/panel.ui.h:7
 msgid "Applets"
@@ -40,64 +38,64 @@ msgstr "Applets"
 #: ../src/raven/main_view.vala:75
 #: ../src/panel/applets/notifications/NotificationsApplet.plugin.in.h:1
 msgid "Notifications"
-msgstr "Notifikationer"
+msgstr "Notificacións"
 
 #: ../src/raven/settings_view.vala:266
 msgid "Top"
-msgstr "Top"
+msgstr "Arriba"
 
 #: ../src/raven/settings_view.vala:268
 msgid "Bottom"
-msgstr "Bund"
+msgstr "Abaixo"
 
 #: ../src/raven/settings_view.vala:376
 msgid "Top Panel"
-msgstr "Toppanel"
+msgstr "Panel superior"
 
 #: ../src/raven/settings_view.vala:378
 msgid "Right Panel"
-msgstr "Højre panel"
+msgstr "Panel dereito"
 
 #: ../src/raven/settings_view.vala:380
 msgid "Left Panel"
-msgstr "Venstre panel"
+msgstr "Panel esquerdo"
 
 #: ../src/raven/settings_view.vala:382
 msgid "Bottom Panel"
-msgstr "Bundpanel"
+msgstr "Panel inferior"
 
 #: ../src/raven/settings_view.vala:616
 msgid "Start"
-msgstr "Start"
+msgstr "Iniciar"
 
 #: ../src/raven/settings_view.vala:619
 msgid "Center"
-msgstr "Midt"
+msgstr "Centro"
 
 #: ../src/raven/settings_view.vala:622
 msgid "End"
-msgstr "Slut"
+msgstr "Fin"
 
 #. Appearance expander
 #: ../src/raven/settings_view.vala:960
 msgid "Appearance"
-msgstr "Udseende"
+msgstr "Aparencia"
 
 #: ../src/raven/settings_view.vala:967
 msgid "Background"
-msgstr "Baggrund"
+msgstr "Fondo"
 
 #: ../src/raven/settings_view.vala:974
 msgid "Fonts"
-msgstr "Skrifttyper"
+msgstr "Fontes"
 
 #: ../src/raven/settings_view.vala:980
 msgid "Windows"
-msgstr "Vinduer"
+msgstr "Ventás"
 
 #: ../src/raven/settings_view.vala:984
 msgid "General"
-msgstr "Generelt"
+msgstr "Xeral"
 
 #: ../src/raven/settings_view.vala:995 ../src/raven/settings_view.vala:996
 msgid "Panel"
@@ -105,35 +103,35 @@ msgstr "Panel"
 
 #: ../src/raven/notifications_view.vala:74
 msgid "Nothing to see here"
-msgstr "Intet at se her"
+msgstr "Nada que ver aquí"
 
 #: ../src/raven/notifications_view.vala:516
 #: ../src/panel/applets/notifications/NotificationsApplet.vala:75
 #, c-format
 msgid "%u unread notifications"
-msgstr "%u ulæste notifikationer"
+msgstr "%u notificacións non lidas"
 
 #: ../src/raven/notifications_view.vala:518
 #: ../src/panel/applets/notifications/NotificationsApplet.vala:77
 msgid "1 unread notification"
-msgstr "1 ulæst notifikation"
+msgstr "1 notificación por ler"
 
 #: ../src/raven/notifications_view.vala:520
 #: ../src/panel/applets/notifications/NotificationsApplet.vala:79
 msgid "No unread notifications"
-msgstr "Ingen ulæste notifikationer"
+msgstr "Non hai notificacións por ler"
 
 #: ../src/raven/notifications_view.vala:646
 msgid "No new notifications"
-msgstr "Ingen nye notifikationer"
+msgstr "Non hai notificacións novas"
 
 #: ../src/raven/sound.vala:78
 msgid "Output"
-msgstr "Output"
+msgstr "Saída"
 
 #: ../src/raven/sound.vala:95
 msgid "Input"
-msgstr "Input"
+msgstr "Entrada"
 
 #. End class
 #. * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
@@ -148,302 +146,302 @@ msgstr "Input"
 #. * :indentSize=4:tabSize=4:noTabs=true:
 #: ../src/panel/applets/spacer/settings.ui.h:1
 msgid "Spacer size"
-msgstr "Størrelse på afstandsstykke"
+msgstr "Tamaño do espazador"
 
 #: ../src/raven/ui/settings.ui.h:1
 msgid "Budgie Settings"
-msgstr "Indstillinger for Budgie"
+msgstr "Configuracións do Budgie"
 
 #: ../src/raven/ui/settings.ui.h:2
 msgid "Exit"
-msgstr "Afslut"
+msgstr "Saír"
 
 #: ../src/raven/ui/applets.ui.h:1
 msgid "Add new applet"
-msgstr "Tilføj ny applet"
+msgstr "Engadir novo applet"
 
 #: ../src/raven/ui/appearance.ui.h:1
 msgid "Use the dark theme"
-msgstr "Brug det mørke tema"
+msgstr "Empregar o tema escuro"
 
 #: ../src/raven/ui/appearance.ui.h:2
 msgid "Dark theme"
-msgstr "Mørkt tema"
+msgstr "Tema escuro"
 
 #: ../src/raven/ui/appearance.ui.h:3
 msgid "Select a GTK+ theme"
-msgstr "Vælg et GTK+-tema"
+msgstr "Escolle un tema GTK+"
 
 #: ../src/raven/ui/appearance.ui.h:4
 msgid "Widget Theme"
-msgstr "Kontroltema"
+msgstr "Tema do widget"
 
 #: ../src/raven/ui/appearance.ui.h:5
 msgid "Select an icon theme"
-msgstr "Vælg et ikontema"
+msgstr "Escolle un tema de iconas"
 
 #: ../src/raven/ui/appearance.ui.h:6
 msgid "Icon Theme"
-msgstr "Ikontema"
+msgstr "Tema de iconas"
 
 #: ../src/raven/ui/appearance.ui.h:7
 msgid "Override defaults"
-msgstr "Tilsidesæt standarder"
+msgstr "Restaurar valores iniciais"
 
 #: ../src/raven/ui/appearance.ui.h:8
 msgid "Built-in theme"
-msgstr "Indbygget tema"
+msgstr "Tema por defecto"
 
 #: ../src/raven/ui/appearance.ui.h:9
 msgid "Select a cursor theme"
-msgstr "Vælg et markørtema"
+msgstr "Escolle o tema do cursor"
 
 #: ../src/raven/ui/appearance.ui.h:10
 msgid "Cursor Theme"
-msgstr "Markørtema"
+msgstr "Tema do cursor"
 
 #: ../src/raven/ui/panel.ui.h:1
 msgid "Manage Panels"
-msgstr "Håndtér paneler"
+msgstr "Manexar paneis"
 
 #: ../src/raven/ui/panel.ui.h:2
 msgid "Position"
-msgstr "Placering"
+msgstr "Posición"
 
 #: ../src/raven/ui/panel.ui.h:3
 msgid "Size"
-msgstr "Størrelse"
+msgstr "Tamaño"
 
 #: ../src/raven/ui/panel.ui.h:4
 msgid "Shadow"
-msgstr "Skygge"
+msgstr "Sombra"
 
 #: ../src/raven/ui/panel.ui.h:5
 msgid "Autohide policy"
-msgstr "Skjul retningslinjer automatisk"
+msgstr "Comportamento da ocultación automática"
 
 #: ../src/raven/ui/panel.ui.h:6
 msgid "Stylize regions"
-msgstr "Stilisér regioner"
+msgstr "Delimitar zonas"
 
 #: ../src/raven/ui/background.ui.h:1
 msgid "Show desktop icons"
-msgstr "Vis skrivebordsikoner"
+msgstr "Amosar iconas do escritorio"
 
 #: ../src/raven/ui/background.ui.h:2
 msgid "Desktop Icons"
-msgstr "Skrivebordsikoner"
+msgstr "Iconas do escritorio"
 
 #: ../src/raven/ui/fonts.ui.h:1
 msgid "Window Titles"
-msgstr "Vinduestitler"
+msgstr "Títulos da ventá"
 
 #: ../src/raven/ui/fonts.ui.h:2
 msgid "Interface"
-msgstr "Brugerflade"
+msgstr "Interface"
 
 #: ../src/raven/ui/fonts.ui.h:3
 msgid "Documents"
-msgstr "Dokumenter"
+msgstr "Documentos"
 
 #: ../src/raven/ui/fonts.ui.h:4
 msgid "Monospace"
-msgstr "Fastbredde"
+msgstr "Monospace"
 
 #: ../src/raven/ui/wm.ui.h:1
 msgid "Disable unredirect of fullscreen windows"
-msgstr "Deaktivér uomdirigering af fuldskærmsvinduer"
+msgstr "Deshabilitar desredireccionamento de xanelas de pantalla completa"
 
 #: ../src/raven/ui/wm.ui.h:2
 msgid "Disable unredirect"
-msgstr "Deaktivér uomdirigering"
+msgstr "Deshabilitar desredireccionamento"
 
 #: ../src/raven/ui/wm.ui.h:3
 msgid "Change the layout of the window buttons"
-msgstr "Skift vinduesknappernes layout"
+msgstr "Mudar o deseño dos botóns das ventás"
 
 #: ../src/raven/ui/wm.ui.h:4
 msgid "Button layout"
-msgstr "Tastlayout"
+msgstr "Deseño do botón"
 
 #: ../src/session/budgie-desktop.desktop.in.in.h:1
 #: ../src/session/budgie-desktop.session.in.in.h:1
 msgid "Budgie Desktop"
-msgstr "Budgie-skrivebord"
+msgstr "Escritorio do Budgie"
 
 #: ../src/session/budgie-desktop.desktop.in.in.h:2
 msgid "This session logs you into the Budgie Desktop"
-msgstr "Denne session logger dig ind i Budgie-skrivebordet"
+msgstr "Esta sesión conéctache ao Escritorio do Budgie"
 
 #: ../src/daemon/endsession.ui.h:2
 msgid "Are you sure you want to end your session?"
-msgstr "Er du sikker på, at du vil afslutte din session?"
+msgstr "Estás seguro de finalizar a sesión?"
 
 #: ../src/daemon/endsession.ui.h:3
 msgid "Cancel"
-msgstr "Annullér"
+msgstr "Cancelar"
 
 #. IndicatorItem switch_user_menu = new IndicatorItem(_("Switch User"),
 #. "network-transmit-receive-symbolic", false);
 #: ../src/daemon/endsession.ui.h:4
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:179
 msgid "Logout"
-msgstr "Log ud"
+msgstr "Desconectar"
 
 #: ../src/daemon/endsession.ui.h:5
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:104
 msgid "Restart"
-msgstr "Genstart"
+msgstr "Reiniciar"
 
 #: ../src/daemon/endsession.ui.h:6
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:105
 msgid "Shutdown"
-msgstr "Luk ned"
+msgstr "Apagar"
 
 #: ../src/panel/applets/clock/ClockApplet.vala:55
 msgid "Time and date settings"
-msgstr "Indstillinger for klokkeslæt og dato"
+msgstr "Configuración de data e hora"
 
 #: ../src/panel/applets/clock/ClockApplet.vala:56
 msgid "Calendar"
-msgstr "Kalender"
+msgstr "Calendario"
 
 #: ../src/panel/applets/icon-tasklist/Buttons.vala:90
 msgid "Pin to panel"
-msgstr "Fastgør til panel"
+msgstr "Colar ao panel"
 
 #: ../src/panel/applets/icon-tasklist/Buttons.vala:91
 #: ../src/panel/applets/icon-tasklist/Buttons.vala:455
 msgid "Unpin from panel"
-msgstr "Frigør fra panel"
+msgstr "Descolar do panel"
 
 #. Special case, "All"
 #: ../src/panel/applets/budgie-menu/BudgieMenuWindow.vala:31
 msgid "All"
-msgstr "Alle"
+msgstr "Todos"
 
 #: ../src/panel/applets/lock-keys/LockKeysApplet.vala:53
 msgid "Caps lock is active"
-msgstr "CapsLock er aktiv"
+msgstr "Bloqueo maiúsculas activado"
 
 #: ../src/panel/applets/lock-keys/LockKeysApplet.vala:56
 msgid "Caps lock is not active"
-msgstr "CapsLock er ikke aktiv"
+msgstr "Bloqueo maiúsculas desactivado"
 
 #: ../src/panel/applets/lock-keys/LockKeysApplet.vala:66
 msgid "Num lock is active"
-msgstr "NumLock er aktiv"
+msgstr "Bloqueo numérico activado"
 
 #: ../src/panel/applets/lock-keys/LockKeysApplet.vala:69
 msgid "Num lock is not active"
-msgstr "NumLock er ikke aktiv"
+msgstr "Bloqueo numérico desactivado"
 
 #: ../src/panel/applets/show-desktop/ShowDesktopApplet.vala:33
 msgid "Toggle the desktop"
-msgstr "Skrivebord til/fra"
+msgstr "Mudar de escritorio"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:101
 msgid "Bluetooth is disabled"
-msgstr "Bluetooth er deaktiveret"
+msgstr "Bluetooth desactivado"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:105
 msgid "Bluetooth is active"
-msgstr "Bluetooth er aktiv"
+msgstr "Bluetooth activado"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:110
 #, c-format
 msgid "Connected to %d device"
 msgid_plural "Connected to %d devices"
-msgstr[0] "Tilsluttet til %d enhed"
-msgstr[1] "Tilsluttet til %d enheder"
+msgstr[0] "Conectado ao dispositivo %d"
+msgstr[1] "Conectado a %d dispositivos"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:171
 msgid "Bluetooth Settings"
-msgstr "Indstillinger for Bluetooth"
+msgstr "Configuración do Bluetooth"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:172
 msgid "Send Files"
-msgstr "Send filer"
+msgstr "Enviar ficheiros"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:173
 msgid "Bluetooth Airplane Mode"
-msgstr "Flytilstand for Bluetooth"
+msgstr "Bluetooth en Modo Avión"
 
 #: ../src/panel/applets/status/PowerIndicator.vala:56
 msgid "Battery fully charged."
-msgstr "Batteri fuldt opladet."
+msgstr "Batería cargada"
 
 #: ../src/panel/applets/status/PowerIndicator.vala:59
 msgid "Unknown"
-msgstr "Ukendt"
+msgstr "Descoñecido"
 
 #. Set inner charging duration to hours:minutes
 #: ../src/panel/applets/status/PowerIndicator.vala:68
 msgid "Battery charging"
-msgstr "Batteri lader op"
+msgstr "Batería cargando"
 
 #: ../src/panel/applets/status/PowerIndicator.vala:73
 msgid "Battery remaining"
-msgstr "Tilbageværende batteri"
+msgstr "Batería dispoñíbel"
 
 #: ../src/panel/applets/status/PowerIndicator.vala:107
 msgid "Power settings"
-msgstr "Strømindstillinger"
+msgstr "Configuración de enerxía"
 
 #. User Menu Creation
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:95
 msgid "User"
-msgstr "Bruger"
+msgstr "Usuario"
 
 #. Default to "User" and symbolic icon
 #. The rest
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:101
 msgid "Lock"
-msgstr "Lås"
+msgstr "Bloquear"
 
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:102
 msgid "Suspend"
-msgstr "Hviletilstand"
+msgstr "Suspender"
 
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:103
 msgid "Hibernate"
-msgstr "Dvaletilstand"
+msgstr "Hibernar"
 
 #: ../src/wm/windowmenu.vala:124
 msgid "Minimize"
-msgstr "Minimér"
+msgstr "Minimizar"
 
 #: ../src/wm/windowmenu.vala:129
 msgid "Unmaximize"
-msgstr "Afmaksimér"
+msgstr "Restaurar"
 
 #: ../src/wm/windowmenu.vala:134
 msgid "Maximize"
-msgstr "Maksimér"
+msgstr "Maximizar"
 
 #: ../src/wm/windowmenu.vala:139
 msgid "Move"
-msgstr "Flyt"
+msgstr "Mover"
 
 #: ../src/wm/windowmenu.vala:144
 msgid "Resize"
-msgstr "Ændr størrelse"
+msgstr "Mudar o tamaño"
 
 #: ../src/wm/windowmenu.vala:149
 msgid "Always On Top"
-msgstr "Altid øverst"
+msgstr "Sempre enriba"
 
 #: ../src/wm/windowmenu.vala:154
 msgid "Close"
-msgstr "Luk"
+msgstr "Fechar"
 
 #: ../src/wm/wm.vala:519
 msgid "Change background"
-msgstr "Skift baggrund"
+msgstr "Mudar o fondo"
 
 #: ../src/wm/wm.vala:528
 msgid "Settings"
-msgstr "Indstillinger"
+msgstr "Configuracións"
 
 #. End BudgieWMDBUS
 #. End namespace
@@ -459,135 +457,135 @@ msgstr "Indstillinger"
 #. * :indentSize=4:tabSize=4:noTabs=true:
 #: ../src/panel/applets/clock/ClockApplet.plugin.in.h:1
 msgid "Clock"
-msgstr "Ur"
+msgstr "Reloxo"
 
 #: ../src/panel/applets/show-desktop/ShowDesktopApplet.plugin.in.h:1
 msgid "Show Desktop Button"
-msgstr "Vis skrivebordsknap"
+msgstr "Amosar botón do escritorio"
 
 #: ../src/panel/applets/tasklist/TasklistApplet.plugin.in.h:1
 msgid "Task List"
-msgstr "Opgaveliste"
+msgstr "Lista de tarefas"
 
 #: ../src/panel/applets/places-indicator/PlacesIndicator.plugin.in.h:1
 #: ../src/panel/applets/places-indicator/PlacesIndicator.vala:80
 #: ../src/panel/applets/places-indicator/PlacesSection.vala:32
 msgid "Places"
-msgstr "Steder"
+msgstr "Localizacións"
 
 #: ../src/panel/applets/icon-tasklist/IconTasklistApplet.plugin.in.h:1
 msgid "Icon Task List"
-msgstr "Opgaveliste med ikoner"
+msgstr "Icona da lista de tarefas"
 
 #: ../src/panel/applets/lock-keys/LockKeysApplet.plugin.in.h:1
 msgid "Lock Keys Indicator"
-msgstr "Indikator for låsetaster"
+msgstr "Indicador do bloqueo de teclado"
 
 #: ../src/panel/applets/raven-trigger/RavenTriggerApplet.plugin.in.h:1
 msgid "Raven Sidebar Control"
-msgstr "Raven sidepanelindstillinger"
+msgstr "Control da barra lateral do Raven"
 
 #: ../src/panel/applets/spacer/SpacerApplet.plugin.in.h:1
 msgid "Spacer"
-msgstr "Afstandsstykke"
+msgstr "Espazador"
 
 #: ../src/panel/applets/user-indicator/UserIndicator.plugin.in.h:1
 msgid "User Indicator"
-msgstr "Brugerindikator"
+msgstr "Indicador de usuario"
 
 #: ../src/panel/applets/workspaces/WorkspacesApplet.plugin.in.h:1
 msgid "Workspace Switcher"
-msgstr "Arbejdsområdeskifter"
+msgstr "Alternar espazo de traballo"
 
 #: ../src/panel/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in.h:1
 msgid "Keyboard Layout Indicator"
-msgstr "Indikator for tastaturlayout"
+msgstr "Indicador da disposición do teclado"
 
 #: ../src/panel/applets/tray/TrayApplet.plugin.in.h:1
 msgid "System Tray"
-msgstr "Statusbakke"
+msgstr "Bandexa do sistema"
 
 #: ../src/panel/applets/status/StatusApplet.plugin.in.h:1
 msgid "Status Indicator"
-msgstr "Statusindikator"
+msgstr "Indicador de estado"
 
 #: ../src/panel/applets/budgie-menu/BudgieMenu.plugin.in.h:1
 msgid "Budgie Menu"
-msgstr "Budgie-menu"
+msgstr "Menú do Budgie"
 
 #: ../src/panel/applets/separator/SeparatorApplet.plugin.in.h:1
 msgid "Separator"
-msgstr "Separator"
+msgstr "Separador"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:23
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:23
 msgid "Removable devices"
-msgstr "Fjernbare enheder"
+msgstr "Dispositivos removíbeis"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:25
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:25
 msgid "Local volumes"
-msgstr "Lokale volumener"
+msgstr "Volumes locais"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:29
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:29
 msgid "Network folders"
-msgstr "Netværksmapper"
+msgstr "Carpetas de rede"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:32
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:32
 msgid "Other"
-msgstr "Andet"
+msgstr "Outros"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:52
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:49
 msgid "Eject"
-msgstr "Skub ud"
+msgstr "Expulsar"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:54
 msgid "Unmount"
-msgstr "Afmonter"
+msgstr "Desconectar"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:57
 #: ../src/panel/applets/places-indicator/PlaceItem.vala:27
 #, c-format
 msgid "Open \"%s\""
-msgstr "Åbn \"%s\""
+msgstr "Abrir \"%s\""
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:81
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:56
 msgid "You can now safely remove"
-msgstr "Du kan nu sikkert fjerne"
+msgstr "Pódese retirar con seguridade"
 
 #: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:139
 msgid "Nothing to display right now"
-msgstr "Intet at vise lige nu"
+msgstr "Nada que mostrar neste intre"
 
 #: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Mount some drives"
-msgstr "Monter nogle drev"
+msgstr "Conectar algúns dispositivos"
 
 #: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Enable more sections"
-msgstr "Aktivér flere afsnit"
+msgstr "Activar máis seccións"
 
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:67
 #, c-format
 msgid "Mount and open \"%s\""
-msgstr "Monter og åbn \"%s\""
+msgstr "Montar e abrir \"%s\""
 
 #: ../src/panel/applets/places-indicator/settings.ui.h:1
 msgid "Show label"
-msgstr "Vis etiket"
+msgstr "Amosar etiqueta"
 
 #: ../src/panel/applets/places-indicator/settings.ui.h:2
 msgid "Show places"
-msgstr "Vis steder"
+msgstr "Amosar localizacións"
 
 #: ../src/panel/applets/places-indicator/settings.ui.h:3
 msgid "Show removable drives"
-msgstr "Vis drev der kan fjernes"
+msgstr "Amosar unidades extraíbeis"
 
 #: ../src/panel/applets/places-indicator/settings.ui.h:4
 msgid "Show network folders"
-msgstr "Vis netværksmapper"
+msgstr "Amosar carpetas de rede"

--- a/po/gl_ES.po
+++ b/po/gl_ES.po
@@ -3,35 +3,32 @@
 # This file is distributed under the same license as the PACKAGE package.
 # 
 # Translators:
-# Johan Møller Borgstrøm <johan.budh@gmail.com>, 2015
-# Kris Thomsen <lakristho@gmail.com>, 2015-2016
-# scootergrisen, 2017
-# Thorbjørn Erik Køppen Christensen <awwkaw@gmail.com>, 2017
+# Xosé Duncan <xoseduncan@gmail.com>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Budgie Desktop\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-26 04:02+0100\n"
-"PO-Revision-Date: 2017-04-14 19:06+0000\n"
-"Last-Translator: scootergrisen\n"
-"Language-Team: Danish (http://www.transifex.com/budgie-desktop/budgie-desktop/language/da/)\n"
+"PO-Revision-Date: 2017-02-12 20:21+0000\n"
+"Last-Translator: Xosé Duncan <xoseduncan@gmail.com>\n"
+"Language-Team: Galician (Spain) (http://www.transifex.com/budgie-desktop/budgie-desktop/language/gl_ES/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: da\n"
+"Language: gl_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../src/daemon/endsession.vala:167
 msgid "Log out"
-msgstr "Log ud"
+msgstr "Pechar sesión"
 
 #: ../src/daemon/endsession.vala:171
 msgid "Restart device"
-msgstr "Genstart enhed"
+msgstr "Reiniciar"
 
 #: ../src/daemon/endsession.vala:183 ../src/daemon/endsession.ui.h:1
 msgid "Power Off"
-msgstr "Sluk"
+msgstr "Apagar"
 
 #: ../src/raven/main_view.vala:72 ../src/raven/ui/panel.ui.h:7
 msgid "Applets"
@@ -40,64 +37,64 @@ msgstr "Applets"
 #: ../src/raven/main_view.vala:75
 #: ../src/panel/applets/notifications/NotificationsApplet.plugin.in.h:1
 msgid "Notifications"
-msgstr "Notifikationer"
+msgstr "Notificacións"
 
 #: ../src/raven/settings_view.vala:266
 msgid "Top"
-msgstr "Top"
+msgstr "Arriba"
 
 #: ../src/raven/settings_view.vala:268
 msgid "Bottom"
-msgstr "Bund"
+msgstr "Abaixo"
 
 #: ../src/raven/settings_view.vala:376
 msgid "Top Panel"
-msgstr "Toppanel"
+msgstr "Panel superior"
 
 #: ../src/raven/settings_view.vala:378
 msgid "Right Panel"
-msgstr "Højre panel"
+msgstr "Panel dereito"
 
 #: ../src/raven/settings_view.vala:380
 msgid "Left Panel"
-msgstr "Venstre panel"
+msgstr "Panel esquerdo"
 
 #: ../src/raven/settings_view.vala:382
 msgid "Bottom Panel"
-msgstr "Bundpanel"
+msgstr "Panel inferior"
 
 #: ../src/raven/settings_view.vala:616
 msgid "Start"
-msgstr "Start"
+msgstr "Iniciar"
 
 #: ../src/raven/settings_view.vala:619
 msgid "Center"
-msgstr "Midt"
+msgstr "Centro"
 
 #: ../src/raven/settings_view.vala:622
 msgid "End"
-msgstr "Slut"
+msgstr "Fin"
 
 #. Appearance expander
 #: ../src/raven/settings_view.vala:960
 msgid "Appearance"
-msgstr "Udseende"
+msgstr "Aparencia"
 
 #: ../src/raven/settings_view.vala:967
 msgid "Background"
-msgstr "Baggrund"
+msgstr "Fondo"
 
 #: ../src/raven/settings_view.vala:974
 msgid "Fonts"
-msgstr "Skrifttyper"
+msgstr "Fontes"
 
 #: ../src/raven/settings_view.vala:980
 msgid "Windows"
-msgstr "Vinduer"
+msgstr "Ventás"
 
 #: ../src/raven/settings_view.vala:984
 msgid "General"
-msgstr "Generelt"
+msgstr "Xeral"
 
 #: ../src/raven/settings_view.vala:995 ../src/raven/settings_view.vala:996
 msgid "Panel"
@@ -105,35 +102,35 @@ msgstr "Panel"
 
 #: ../src/raven/notifications_view.vala:74
 msgid "Nothing to see here"
-msgstr "Intet at se her"
+msgstr "Nada que ver aquí"
 
 #: ../src/raven/notifications_view.vala:516
 #: ../src/panel/applets/notifications/NotificationsApplet.vala:75
 #, c-format
 msgid "%u unread notifications"
-msgstr "%u ulæste notifikationer"
+msgstr "%u notificacións non lidas"
 
 #: ../src/raven/notifications_view.vala:518
 #: ../src/panel/applets/notifications/NotificationsApplet.vala:77
 msgid "1 unread notification"
-msgstr "1 ulæst notifikation"
+msgstr "1 notificación por ler"
 
 #: ../src/raven/notifications_view.vala:520
 #: ../src/panel/applets/notifications/NotificationsApplet.vala:79
 msgid "No unread notifications"
-msgstr "Ingen ulæste notifikationer"
+msgstr "Non hai notificacións por ler"
 
 #: ../src/raven/notifications_view.vala:646
 msgid "No new notifications"
-msgstr "Ingen nye notifikationer"
+msgstr "Non hai notificacións novas"
 
 #: ../src/raven/sound.vala:78
 msgid "Output"
-msgstr "Output"
+msgstr "Saída"
 
 #: ../src/raven/sound.vala:95
 msgid "Input"
-msgstr "Input"
+msgstr "Entrada"
 
 #. End class
 #. * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
@@ -148,302 +145,302 @@ msgstr "Input"
 #. * :indentSize=4:tabSize=4:noTabs=true:
 #: ../src/panel/applets/spacer/settings.ui.h:1
 msgid "Spacer size"
-msgstr "Størrelse på afstandsstykke"
+msgstr "Tamaño do espazador"
 
 #: ../src/raven/ui/settings.ui.h:1
 msgid "Budgie Settings"
-msgstr "Indstillinger for Budgie"
+msgstr "Configuracións do Budgie"
 
 #: ../src/raven/ui/settings.ui.h:2
 msgid "Exit"
-msgstr "Afslut"
+msgstr "Saír"
 
 #: ../src/raven/ui/applets.ui.h:1
 msgid "Add new applet"
-msgstr "Tilføj ny applet"
+msgstr "Engadir novo applet"
 
 #: ../src/raven/ui/appearance.ui.h:1
 msgid "Use the dark theme"
-msgstr "Brug det mørke tema"
+msgstr "Empregar o tema escuro"
 
 #: ../src/raven/ui/appearance.ui.h:2
 msgid "Dark theme"
-msgstr "Mørkt tema"
+msgstr "Tema escuro"
 
 #: ../src/raven/ui/appearance.ui.h:3
 msgid "Select a GTK+ theme"
-msgstr "Vælg et GTK+-tema"
+msgstr "Escolle un tema GTK+"
 
 #: ../src/raven/ui/appearance.ui.h:4
 msgid "Widget Theme"
-msgstr "Kontroltema"
+msgstr "Tema do widget"
 
 #: ../src/raven/ui/appearance.ui.h:5
 msgid "Select an icon theme"
-msgstr "Vælg et ikontema"
+msgstr "Escolle un tema de iconas"
 
 #: ../src/raven/ui/appearance.ui.h:6
 msgid "Icon Theme"
-msgstr "Ikontema"
+msgstr "Tema de iconas"
 
 #: ../src/raven/ui/appearance.ui.h:7
 msgid "Override defaults"
-msgstr "Tilsidesæt standarder"
+msgstr "Restaurar valores iniciais"
 
 #: ../src/raven/ui/appearance.ui.h:8
 msgid "Built-in theme"
-msgstr "Indbygget tema"
+msgstr "Tema por defecto"
 
 #: ../src/raven/ui/appearance.ui.h:9
 msgid "Select a cursor theme"
-msgstr "Vælg et markørtema"
+msgstr "Escolle o tema do cursor"
 
 #: ../src/raven/ui/appearance.ui.h:10
 msgid "Cursor Theme"
-msgstr "Markørtema"
+msgstr "Tema do cursor"
 
 #: ../src/raven/ui/panel.ui.h:1
 msgid "Manage Panels"
-msgstr "Håndtér paneler"
+msgstr "Manexar paneis"
 
 #: ../src/raven/ui/panel.ui.h:2
 msgid "Position"
-msgstr "Placering"
+msgstr "Posición"
 
 #: ../src/raven/ui/panel.ui.h:3
 msgid "Size"
-msgstr "Størrelse"
+msgstr "Tamaño"
 
 #: ../src/raven/ui/panel.ui.h:4
 msgid "Shadow"
-msgstr "Skygge"
+msgstr "Sombra"
 
 #: ../src/raven/ui/panel.ui.h:5
 msgid "Autohide policy"
-msgstr "Skjul retningslinjer automatisk"
+msgstr "Comportamento da ocultación automática"
 
 #: ../src/raven/ui/panel.ui.h:6
 msgid "Stylize regions"
-msgstr "Stilisér regioner"
+msgstr "Delimitar zonas"
 
 #: ../src/raven/ui/background.ui.h:1
 msgid "Show desktop icons"
-msgstr "Vis skrivebordsikoner"
+msgstr "Amosar iconas do escritorio"
 
 #: ../src/raven/ui/background.ui.h:2
 msgid "Desktop Icons"
-msgstr "Skrivebordsikoner"
+msgstr "Iconas do escritorio"
 
 #: ../src/raven/ui/fonts.ui.h:1
 msgid "Window Titles"
-msgstr "Vinduestitler"
+msgstr "Títulos da ventá"
 
 #: ../src/raven/ui/fonts.ui.h:2
 msgid "Interface"
-msgstr "Brugerflade"
+msgstr "Interface"
 
 #: ../src/raven/ui/fonts.ui.h:3
 msgid "Documents"
-msgstr "Dokumenter"
+msgstr "Documentos"
 
 #: ../src/raven/ui/fonts.ui.h:4
 msgid "Monospace"
-msgstr "Fastbredde"
+msgstr "Monospace"
 
 #: ../src/raven/ui/wm.ui.h:1
 msgid "Disable unredirect of fullscreen windows"
-msgstr "Deaktivér uomdirigering af fuldskærmsvinduer"
+msgstr "Deshabilitar desredireccionamento de xanelas de pantalla completa"
 
 #: ../src/raven/ui/wm.ui.h:2
 msgid "Disable unredirect"
-msgstr "Deaktivér uomdirigering"
+msgstr "Deshabilitar desredireccionamento"
 
 #: ../src/raven/ui/wm.ui.h:3
 msgid "Change the layout of the window buttons"
-msgstr "Skift vinduesknappernes layout"
+msgstr "Mudar o deseño dos botóns das ventás"
 
 #: ../src/raven/ui/wm.ui.h:4
 msgid "Button layout"
-msgstr "Tastlayout"
+msgstr "Deseño do botón"
 
 #: ../src/session/budgie-desktop.desktop.in.in.h:1
 #: ../src/session/budgie-desktop.session.in.in.h:1
 msgid "Budgie Desktop"
-msgstr "Budgie-skrivebord"
+msgstr "Escritorio do Budgie"
 
 #: ../src/session/budgie-desktop.desktop.in.in.h:2
 msgid "This session logs you into the Budgie Desktop"
-msgstr "Denne session logger dig ind i Budgie-skrivebordet"
+msgstr "Esta sesión conéctache ao Escritorio do Budgie"
 
 #: ../src/daemon/endsession.ui.h:2
 msgid "Are you sure you want to end your session?"
-msgstr "Er du sikker på, at du vil afslutte din session?"
+msgstr "Estás seguro de finalizar a sesión?"
 
 #: ../src/daemon/endsession.ui.h:3
 msgid "Cancel"
-msgstr "Annullér"
+msgstr "Cancelar"
 
 #. IndicatorItem switch_user_menu = new IndicatorItem(_("Switch User"),
 #. "network-transmit-receive-symbolic", false);
 #: ../src/daemon/endsession.ui.h:4
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:179
 msgid "Logout"
-msgstr "Log ud"
+msgstr "Desconectar"
 
 #: ../src/daemon/endsession.ui.h:5
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:104
 msgid "Restart"
-msgstr "Genstart"
+msgstr "Reiniciar"
 
 #: ../src/daemon/endsession.ui.h:6
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:105
 msgid "Shutdown"
-msgstr "Luk ned"
+msgstr "Apagar"
 
 #: ../src/panel/applets/clock/ClockApplet.vala:55
 msgid "Time and date settings"
-msgstr "Indstillinger for klokkeslæt og dato"
+msgstr "Configuración de data e hora"
 
 #: ../src/panel/applets/clock/ClockApplet.vala:56
 msgid "Calendar"
-msgstr "Kalender"
+msgstr "Calendario"
 
 #: ../src/panel/applets/icon-tasklist/Buttons.vala:90
 msgid "Pin to panel"
-msgstr "Fastgør til panel"
+msgstr "Colar ao panel"
 
 #: ../src/panel/applets/icon-tasklist/Buttons.vala:91
 #: ../src/panel/applets/icon-tasklist/Buttons.vala:455
 msgid "Unpin from panel"
-msgstr "Frigør fra panel"
+msgstr "Descolar do panel"
 
 #. Special case, "All"
 #: ../src/panel/applets/budgie-menu/BudgieMenuWindow.vala:31
 msgid "All"
-msgstr "Alle"
+msgstr "Todos"
 
 #: ../src/panel/applets/lock-keys/LockKeysApplet.vala:53
 msgid "Caps lock is active"
-msgstr "CapsLock er aktiv"
+msgstr "Bloqueo maiúsculas activado"
 
 #: ../src/panel/applets/lock-keys/LockKeysApplet.vala:56
 msgid "Caps lock is not active"
-msgstr "CapsLock er ikke aktiv"
+msgstr "Bloqueo maiúsculas desactivado"
 
 #: ../src/panel/applets/lock-keys/LockKeysApplet.vala:66
 msgid "Num lock is active"
-msgstr "NumLock er aktiv"
+msgstr "Bloqueo numérico activado"
 
 #: ../src/panel/applets/lock-keys/LockKeysApplet.vala:69
 msgid "Num lock is not active"
-msgstr "NumLock er ikke aktiv"
+msgstr "Bloqueo numérico desactivado"
 
 #: ../src/panel/applets/show-desktop/ShowDesktopApplet.vala:33
 msgid "Toggle the desktop"
-msgstr "Skrivebord til/fra"
+msgstr "Mudar de escritorio"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:101
 msgid "Bluetooth is disabled"
-msgstr "Bluetooth er deaktiveret"
+msgstr "Bluetooth desactivado"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:105
 msgid "Bluetooth is active"
-msgstr "Bluetooth er aktiv"
+msgstr "Bluetooth activado"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:110
 #, c-format
 msgid "Connected to %d device"
 msgid_plural "Connected to %d devices"
-msgstr[0] "Tilsluttet til %d enhed"
-msgstr[1] "Tilsluttet til %d enheder"
+msgstr[0] "Conectado a %d dispositivo"
+msgstr[1] "Conectado a %d dispositivos"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:171
 msgid "Bluetooth Settings"
-msgstr "Indstillinger for Bluetooth"
+msgstr "Configuración do Bluetooth"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:172
 msgid "Send Files"
-msgstr "Send filer"
+msgstr "Enviar ficheiros"
 
 #: ../src/panel/applets/status/BluetoothIndicator.vala:173
 msgid "Bluetooth Airplane Mode"
-msgstr "Flytilstand for Bluetooth"
+msgstr "Bluetooth en Modo Avión"
 
 #: ../src/panel/applets/status/PowerIndicator.vala:56
 msgid "Battery fully charged."
-msgstr "Batteri fuldt opladet."
+msgstr "Batería cargada"
 
 #: ../src/panel/applets/status/PowerIndicator.vala:59
 msgid "Unknown"
-msgstr "Ukendt"
+msgstr "Descoñecido"
 
 #. Set inner charging duration to hours:minutes
 #: ../src/panel/applets/status/PowerIndicator.vala:68
 msgid "Battery charging"
-msgstr "Batteri lader op"
+msgstr "Batería cargando"
 
 #: ../src/panel/applets/status/PowerIndicator.vala:73
 msgid "Battery remaining"
-msgstr "Tilbageværende batteri"
+msgstr "Batería dispoñíbel"
 
 #: ../src/panel/applets/status/PowerIndicator.vala:107
 msgid "Power settings"
-msgstr "Strømindstillinger"
+msgstr "Configuración de enerxía"
 
 #. User Menu Creation
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:95
 msgid "User"
-msgstr "Bruger"
+msgstr "Usuario"
 
 #. Default to "User" and symbolic icon
 #. The rest
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:101
 msgid "Lock"
-msgstr "Lås"
+msgstr "Bloquear"
 
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:102
 msgid "Suspend"
-msgstr "Hviletilstand"
+msgstr "Suspender"
 
 #: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:103
 msgid "Hibernate"
-msgstr "Dvaletilstand"
+msgstr "Hibernar"
 
 #: ../src/wm/windowmenu.vala:124
 msgid "Minimize"
-msgstr "Minimér"
+msgstr "Minimizar"
 
 #: ../src/wm/windowmenu.vala:129
 msgid "Unmaximize"
-msgstr "Afmaksimér"
+msgstr "Restaurar"
 
 #: ../src/wm/windowmenu.vala:134
 msgid "Maximize"
-msgstr "Maksimér"
+msgstr "Maximizar"
 
 #: ../src/wm/windowmenu.vala:139
 msgid "Move"
-msgstr "Flyt"
+msgstr "Mover"
 
 #: ../src/wm/windowmenu.vala:144
 msgid "Resize"
-msgstr "Ændr størrelse"
+msgstr "Mudar o tamaño"
 
 #: ../src/wm/windowmenu.vala:149
 msgid "Always On Top"
-msgstr "Altid øverst"
+msgstr "Sempre enriba"
 
 #: ../src/wm/windowmenu.vala:154
 msgid "Close"
-msgstr "Luk"
+msgstr "Fechar"
 
 #: ../src/wm/wm.vala:519
 msgid "Change background"
-msgstr "Skift baggrund"
+msgstr "Mudar o fondo"
 
 #: ../src/wm/wm.vala:528
 msgid "Settings"
-msgstr "Indstillinger"
+msgstr "Configuracións"
 
 #. End BudgieWMDBUS
 #. End namespace
@@ -459,135 +456,135 @@ msgstr "Indstillinger"
 #. * :indentSize=4:tabSize=4:noTabs=true:
 #: ../src/panel/applets/clock/ClockApplet.plugin.in.h:1
 msgid "Clock"
-msgstr "Ur"
+msgstr "Reloxo"
 
 #: ../src/panel/applets/show-desktop/ShowDesktopApplet.plugin.in.h:1
 msgid "Show Desktop Button"
-msgstr "Vis skrivebordsknap"
+msgstr "Amosar botón do escritorio"
 
 #: ../src/panel/applets/tasklist/TasklistApplet.plugin.in.h:1
 msgid "Task List"
-msgstr "Opgaveliste"
+msgstr "Lista de tarefas"
 
 #: ../src/panel/applets/places-indicator/PlacesIndicator.plugin.in.h:1
 #: ../src/panel/applets/places-indicator/PlacesIndicator.vala:80
 #: ../src/panel/applets/places-indicator/PlacesSection.vala:32
 msgid "Places"
-msgstr "Steder"
+msgstr "Localizacións"
 
 #: ../src/panel/applets/icon-tasklist/IconTasklistApplet.plugin.in.h:1
 msgid "Icon Task List"
-msgstr "Opgaveliste med ikoner"
+msgstr "Icona da lista de tarefas"
 
 #: ../src/panel/applets/lock-keys/LockKeysApplet.plugin.in.h:1
 msgid "Lock Keys Indicator"
-msgstr "Indikator for låsetaster"
+msgstr "Indicador do bloqueo de teclado"
 
 #: ../src/panel/applets/raven-trigger/RavenTriggerApplet.plugin.in.h:1
 msgid "Raven Sidebar Control"
-msgstr "Raven sidepanelindstillinger"
+msgstr "Control da barra lateral do Raven"
 
 #: ../src/panel/applets/spacer/SpacerApplet.plugin.in.h:1
 msgid "Spacer"
-msgstr "Afstandsstykke"
+msgstr "Espazador"
 
 #: ../src/panel/applets/user-indicator/UserIndicator.plugin.in.h:1
 msgid "User Indicator"
-msgstr "Brugerindikator"
+msgstr "Indicador de usuario"
 
 #: ../src/panel/applets/workspaces/WorkspacesApplet.plugin.in.h:1
 msgid "Workspace Switcher"
-msgstr "Arbejdsområdeskifter"
+msgstr "Alternar espazo de traballo"
 
 #: ../src/panel/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in.h:1
 msgid "Keyboard Layout Indicator"
-msgstr "Indikator for tastaturlayout"
+msgstr "Indicador da disposición do teclado"
 
 #: ../src/panel/applets/tray/TrayApplet.plugin.in.h:1
 msgid "System Tray"
-msgstr "Statusbakke"
+msgstr "Bandexa do sistema"
 
 #: ../src/panel/applets/status/StatusApplet.plugin.in.h:1
 msgid "Status Indicator"
-msgstr "Statusindikator"
+msgstr "Indicador de estado"
 
 #: ../src/panel/applets/budgie-menu/BudgieMenu.plugin.in.h:1
 msgid "Budgie Menu"
-msgstr "Budgie-menu"
+msgstr "Menú do Budgie"
 
 #: ../src/panel/applets/separator/SeparatorApplet.plugin.in.h:1
 msgid "Separator"
-msgstr "Separator"
+msgstr "Separador"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:23
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:23
 msgid "Removable devices"
-msgstr "Fjernbare enheder"
+msgstr "Dispositivos removíbeis"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:25
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:25
 msgid "Local volumes"
-msgstr "Lokale volumener"
+msgstr "Volumes locais"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:29
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:29
 msgid "Network folders"
-msgstr "Netværksmapper"
+msgstr "Carpetas de rede"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:32
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:32
 msgid "Other"
-msgstr "Andet"
+msgstr "Outros"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:52
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:49
 msgid "Eject"
-msgstr "Skub ud"
+msgstr "Expulsar"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:54
 msgid "Unmount"
-msgstr "Afmonter"
+msgstr "Desconectar"
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:57
 #: ../src/panel/applets/places-indicator/PlaceItem.vala:27
 #, c-format
 msgid "Open \"%s\""
-msgstr "Åbn \"%s\""
+msgstr "Abrir \"%s\""
 
 #: ../src/panel/applets/places-indicator/MountItem.vala:81
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:56
 msgid "You can now safely remove"
-msgstr "Du kan nu sikkert fjerne"
+msgstr "Pódese retirar con seguridade"
 
 #: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:139
 msgid "Nothing to display right now"
-msgstr "Intet at vise lige nu"
+msgstr "Nada que mostrar neste intre"
 
 #: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Mount some drives"
-msgstr "Monter nogle drev"
+msgstr "Conectar algúns dispositivos"
 
 #: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Enable more sections"
-msgstr "Aktivér flere afsnit"
+msgstr "Activar máis seccións"
 
 #: ../src/panel/applets/places-indicator/VolumeItem.vala:67
 #, c-format
 msgid "Mount and open \"%s\""
-msgstr "Monter og åbn \"%s\""
+msgstr "Montar e abrir \"%s\""
 
 #: ../src/panel/applets/places-indicator/settings.ui.h:1
 msgid "Show label"
-msgstr "Vis etiket"
+msgstr "Amosar etiqueta"
 
 #: ../src/panel/applets/places-indicator/settings.ui.h:2
 msgid "Show places"
-msgstr "Vis steder"
+msgstr "Amosar localizacións"
 
 #: ../src/panel/applets/places-indicator/settings.ui.h:3
 msgid "Show removable drives"
-msgstr "Vis drev der kan fjernes"
+msgstr "Amosar unidades extraíbeis"
 
 #: ../src/panel/applets/places-indicator/settings.ui.h:4
 msgid "Show network folders"
-msgstr "Vis netværksmapper"
+msgstr "Amosar carpetas de rede"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -3,133 +3,137 @@
 # This file is distributed under the same license as the PACKAGE package.
 # 
 # Translators:
+# Antonio Russo Lagnese <antonio.russolagnese@gmail.com>, 2016
 # Marco Martini <deckedspring@gmail.com>, 2015
+# Mugna <marco.mugna@gmail.com>, 2016
+# Matteo Rezzin <rezzinmatteo@gmail.com>, 2016
+# Mugna <marco.mugna@gmail.com>, 2016
 # Viktor Zahariev <vik.z.1995@gmail.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Budgie Desktop\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-10 22:09+0100\n"
-"PO-Revision-Date: 2016-10-10 21:14+0000\n"
-"Last-Translator: Ikey Doherty <ikey@evolve-os.com>\n"
-"Language-Team: Italian (Italy) (http://www.transifex.com/solus-project/budgie-desktop/language/it_IT/)\n"
+"POT-Creation-Date: 2016-10-26 04:02+0100\n"
+"PO-Revision-Date: 2017-02-26 10:02+0000\n"
+"Last-Translator: Michele Vizzani\n"
+"Language-Team: Italian (Italy) (http://www.transifex.com/budgie-desktop/budgie-desktop/language/it_IT/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it_IT\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../daemon/endsession.vala:167
+#: ../src/daemon/endsession.vala:167
 msgid "Log out"
-msgstr ""
+msgstr "Termina sessione"
 
-#: ../daemon/endsession.vala:171
+#: ../src/daemon/endsession.vala:171
 msgid "Restart device"
-msgstr ""
+msgstr "Riavvia"
 
-#: ../daemon/endsession.vala:183 ../daemon/endsession.ui.h:1
+#: ../src/daemon/endsession.vala:183 ../src/daemon/endsession.ui.h:1
 msgid "Power Off"
 msgstr "Spegni"
 
-#: ../raven/main_view.vala:72 ../raven/ui/panel.ui.h:7
+#: ../src/raven/main_view.vala:72 ../src/raven/ui/panel.ui.h:7
 msgid "Applets"
 msgstr "Applet"
 
-#: ../raven/main_view.vala:75
-#: ../panel/applets/notifications/NotificationsApplet.plugin.in.h:1
+#: ../src/raven/main_view.vala:75
+#: ../src/panel/applets/notifications/NotificationsApplet.plugin.in.h:1
 msgid "Notifications"
 msgstr "Notifiche"
 
-#: ../raven/settings_view.vala:266
+#: ../src/raven/settings_view.vala:266
 msgid "Top"
-msgstr "Cima"
+msgstr "Sopra"
 
-#: ../raven/settings_view.vala:268
+#: ../src/raven/settings_view.vala:268
 msgid "Bottom"
-msgstr "Fondo"
+msgstr "Sotto"
 
-#: ../raven/settings_view.vala:376
+#: ../src/raven/settings_view.vala:376
 msgid "Top Panel"
 msgstr "Pannello Superiore"
 
-#: ../raven/settings_view.vala:378
+#: ../src/raven/settings_view.vala:378
 msgid "Right Panel"
 msgstr "Pannello Destro"
 
-#: ../raven/settings_view.vala:380
+#: ../src/raven/settings_view.vala:380
 msgid "Left Panel"
 msgstr "Pannello Sinistro"
 
-#: ../raven/settings_view.vala:382
+#: ../src/raven/settings_view.vala:382
 msgid "Bottom Panel"
 msgstr "Pannello Inferiore"
 
-#: ../raven/settings_view.vala:616
+#: ../src/raven/settings_view.vala:616
 msgid "Start"
 msgstr "Inizio"
 
-#: ../raven/settings_view.vala:619
+#: ../src/raven/settings_view.vala:619
 msgid "Center"
 msgstr "Centro"
 
-#: ../raven/settings_view.vala:622
+#: ../src/raven/settings_view.vala:622
 msgid "End"
 msgstr "Fine"
 
 #. Appearance expander
-#: ../raven/settings_view.vala:960
+#: ../src/raven/settings_view.vala:960
 msgid "Appearance"
 msgstr "Aspetto"
 
-#: ../raven/settings_view.vala:967
+#: ../src/raven/settings_view.vala:967
 msgid "Background"
 msgstr "Sfondo"
 
-#: ../raven/settings_view.vala:974
+#: ../src/raven/settings_view.vala:974
 msgid "Fonts"
-msgstr "Font"
+msgstr "Caratteri"
 
-#: ../raven/settings_view.vala:980
+#: ../src/raven/settings_view.vala:980
 msgid "Windows"
-msgstr ""
+msgstr "Finestre"
 
-#: ../raven/settings_view.vala:984
+#: ../src/raven/settings_view.vala:984
 msgid "General"
 msgstr "Generale"
 
-#: ../raven/settings_view.vala:995 ../raven/settings_view.vala:996
+#: ../src/raven/settings_view.vala:995 ../src/raven/settings_view.vala:996
 msgid "Panel"
 msgstr "Pannello"
 
-#: ../raven/notifications_view.vala:52
+#: ../src/raven/notifications_view.vala:74
 msgid "Nothing to see here"
 msgstr "Niente da vedere qui"
 
-#: ../raven/notifications_view.vala:494
-#: ../panel/applets/notifications/NotificationsApplet.vala:75
+#: ../src/raven/notifications_view.vala:516
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:75
 #, c-format
 msgid "%u unread notifications"
 msgstr "%u notifiche non lette"
 
-#: ../raven/notifications_view.vala:496
-#: ../panel/applets/notifications/NotificationsApplet.vala:77
+#: ../src/raven/notifications_view.vala:518
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:77
 msgid "1 unread notification"
 msgstr "1 notifica non letta"
 
-#: ../raven/notifications_view.vala:498
-#: ../panel/applets/notifications/NotificationsApplet.vala:79
+#: ../src/raven/notifications_view.vala:520
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:79
 msgid "No unread notifications"
 msgstr "Nessuna notifica non letta"
 
-#: ../raven/notifications_view.vala:624
+#: ../src/raven/notifications_view.vala:646
 msgid "No new notifications"
 msgstr "Nessuna nuova notifica"
 
-#: ../raven/sound.vala:78
+#: ../src/raven/sound.vala:78
 msgid "Output"
 msgstr "Output"
 
-#: ../raven/sound.vala:95
+#: ../src/raven/sound.vala:95
 msgid "Input"
 msgstr "Input"
 
@@ -144,304 +148,306 @@ msgstr "Input"
 #. *
 #. * vi: set shiftwidth=4 tabstop=4 expandtab:
 #. * :indentSize=4:tabSize=4:noTabs=true:
-#: ../panel/applets/spacer/settings.ui.h:1
+#: ../src/panel/applets/spacer/settings.ui.h:1
 msgid "Spacer size"
-msgstr "Largezza Spaziatore"
+msgstr "Larghezza Spaziatore"
 
-#: ../raven/ui/settings.ui.h:1
+#: ../src/raven/ui/settings.ui.h:1
 msgid "Budgie Settings"
 msgstr "Impostazioni Budgie"
 
-#: ../raven/ui/settings.ui.h:2
+#: ../src/raven/ui/settings.ui.h:2
 msgid "Exit"
 msgstr "Esci"
 
-#: ../raven/ui/applets.ui.h:1
+#: ../src/raven/ui/applets.ui.h:1
 msgid "Add new applet"
 msgstr "Aggiungi un nuovo applet"
 
-#: ../raven/ui/appearance.ui.h:1
+#: ../src/raven/ui/appearance.ui.h:1
 msgid "Use the dark theme"
 msgstr "Usa il tema scuro"
 
-#: ../raven/ui/appearance.ui.h:2
+#: ../src/raven/ui/appearance.ui.h:2
 msgid "Dark theme"
 msgstr "Tema Scuro"
 
-#: ../raven/ui/appearance.ui.h:3
+#: ../src/raven/ui/appearance.ui.h:3
 msgid "Select a GTK+ theme"
 msgstr "Seleziona un tema GTK+"
 
-#: ../raven/ui/appearance.ui.h:4
+#: ../src/raven/ui/appearance.ui.h:4
 msgid "Widget Theme"
 msgstr "Tema dei Widget"
 
-#: ../raven/ui/appearance.ui.h:5
+#: ../src/raven/ui/appearance.ui.h:5
 msgid "Select an icon theme"
 msgstr "Seleziona un tema delle icone"
 
-#: ../raven/ui/appearance.ui.h:6
+#: ../src/raven/ui/appearance.ui.h:6
 msgid "Icon Theme"
 msgstr "Tema delle Icone"
 
-#: ../raven/ui/appearance.ui.h:7
+#: ../src/raven/ui/appearance.ui.h:7
 msgid "Override defaults"
 msgstr "Sostituisci impostazioni predefinite"
 
-#: ../raven/ui/appearance.ui.h:8
+#: ../src/raven/ui/appearance.ui.h:8
 msgid "Built-in theme"
 msgstr "Tema Predefinito"
 
-#: ../raven/ui/appearance.ui.h:9
+#: ../src/raven/ui/appearance.ui.h:9
 msgid "Select a cursor theme"
 msgstr "Seleziona il tema del cursore"
 
-#: ../raven/ui/appearance.ui.h:10
+#: ../src/raven/ui/appearance.ui.h:10
 msgid "Cursor Theme"
 msgstr "Tema del Cursore"
 
-#: ../raven/ui/panel.ui.h:1
+#: ../src/raven/ui/panel.ui.h:1
 msgid "Manage Panels"
 msgstr "Gestisci Pannelli"
 
-#: ../raven/ui/panel.ui.h:2
+#: ../src/raven/ui/panel.ui.h:2
 msgid "Position"
 msgstr "Posizione"
 
-#: ../raven/ui/panel.ui.h:3
+#: ../src/raven/ui/panel.ui.h:3
 msgid "Size"
-msgstr "Grandezza"
+msgstr "Dimensione"
 
-#: ../raven/ui/panel.ui.h:4
+#: ../src/raven/ui/panel.ui.h:4
 msgid "Shadow"
-msgstr "Ombreggiatura"
+msgstr "Ombra"
 
-#: ../raven/ui/panel.ui.h:5
+#: ../src/raven/ui/panel.ui.h:5
 msgid "Autohide policy"
 msgstr "Metodo di Nascondimento Automatico"
 
-#: ../raven/ui/panel.ui.h:6
+#: ../src/raven/ui/panel.ui.h:6
 msgid "Stylize regions"
 msgstr "Applica stili alle regioni"
 
-#: ../raven/ui/background.ui.h:1
+#: ../src/raven/ui/background.ui.h:1
 msgid "Show desktop icons"
 msgstr "Mostra le icone del desktop"
 
-#: ../raven/ui/background.ui.h:2
+#: ../src/raven/ui/background.ui.h:2
 msgid "Desktop Icons"
 msgstr "Icone del Desktop"
 
-#: ../raven/ui/fonts.ui.h:1
+#: ../src/raven/ui/fonts.ui.h:1
 msgid "Window Titles"
 msgstr "Titoli delle Finestre"
 
-#: ../raven/ui/fonts.ui.h:2
+#: ../src/raven/ui/fonts.ui.h:2
 msgid "Interface"
 msgstr "Interfaccia"
 
-#: ../raven/ui/fonts.ui.h:3
+#: ../src/raven/ui/fonts.ui.h:3
 msgid "Documents"
 msgstr "Documenti"
 
-#: ../raven/ui/fonts.ui.h:4
+#: ../src/raven/ui/fonts.ui.h:4
 msgid "Monospace"
 msgstr "Monospazio"
 
-#: ../raven/ui/wm.ui.h:1
+#: ../src/raven/ui/wm.ui.h:1
 msgid "Disable unredirect of fullscreen windows"
-msgstr ""
+msgstr "Disabilita non reindirizzamento per le finestre a schermo intero"
 
-#: ../raven/ui/wm.ui.h:2
+#: ../src/raven/ui/wm.ui.h:2
 msgid "Disable unredirect"
-msgstr ""
+msgstr "Disabilita non reindirizzamento"
 
-#: ../raven/ui/wm.ui.h:3
+#: ../src/raven/ui/wm.ui.h:3
 msgid "Change the layout of the window buttons"
-msgstr ""
+msgstr "Cambia il layout dei pulsanti a finestra."
 
-#: ../raven/ui/wm.ui.h:4
+#: ../src/raven/ui/wm.ui.h:4
 msgid "Button layout"
-msgstr ""
+msgstr "Posizione dei pulsanti"
 
-#: ../session/budgie-desktop.desktop.in.in.h:1
-#: ../session/budgie-desktop.session.in.in.h:1
+#: ../src/session/budgie-desktop.desktop.in.in.h:1
+#: ../src/session/budgie-desktop.session.in.in.h:1
 msgid "Budgie Desktop"
 msgstr "Desktop Budgie"
 
-#: ../session/budgie-desktop.desktop.in.in.h:2
+#: ../src/session/budgie-desktop.desktop.in.in.h:2
 msgid "This session logs you into the Budgie Desktop"
 msgstr "Questa sessione ti fa entrare nel Desktop Budgie"
 
-#: ../daemon/endsession.ui.h:2
+#: ../src/daemon/endsession.ui.h:2
 msgid "Are you sure you want to end your session?"
 msgstr "Sei sicuro di voler terminare la tua sessione?"
 
-#: ../daemon/endsession.ui.h:3
+#: ../src/daemon/endsession.ui.h:3
 msgid "Cancel"
 msgstr "Annulla"
 
 #. IndicatorItem switch_user_menu = new IndicatorItem(_("Switch User"),
 #. "network-transmit-receive-symbolic", false);
-#: ../daemon/endsession.ui.h:4
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:179
+#: ../src/daemon/endsession.ui.h:4
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:179
 msgid "Logout"
 msgstr "Disconnetti"
 
-#: ../daemon/endsession.ui.h:5
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:104
+#: ../src/daemon/endsession.ui.h:5
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:104
 msgid "Restart"
 msgstr "Riavvia"
 
-#: ../daemon/endsession.ui.h:6
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:105
+#: ../src/daemon/endsession.ui.h:6
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:105
 msgid "Shutdown"
 msgstr "Spegni"
 
-#: ../panel/applets/clock/ClockApplet.vala:55
+#: ../src/panel/applets/clock/ClockApplet.vala:55
 msgid "Time and date settings"
-msgstr "Impostazioni di Data e Ora"
+msgstr "Impostazioni Data e Ora"
 
-#: ../panel/applets/clock/ClockApplet.vala:56
+#: ../src/panel/applets/clock/ClockApplet.vala:56
 msgid "Calendar"
 msgstr "Calendario"
 
-#: ../panel/applets/icon-tasklist/Buttons.vala:90
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:90
 msgid "Pin to panel"
 msgstr "Aggiungi al pannello"
 
-#: ../panel/applets/icon-tasklist/Buttons.vala:91
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:91
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:455
 msgid "Unpin from panel"
-msgstr "Sblocca dal pannello"
+msgstr "Rimuovi dal pannello"
 
 #. Special case, "All"
-#: ../panel/applets/budgie-menu/BudgieMenuWindow.vala:31
+#: ../src/panel/applets/budgie-menu/BudgieMenuWindow.vala:31
 msgid "All"
 msgstr "Tutto"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:53
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:53
 msgid "Caps lock is active"
 msgstr "Block Maiusc è attivo"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:56
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:56
 msgid "Caps lock is not active"
 msgstr "Block Maiusc non è attivo"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:66
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:66
 msgid "Num lock is active"
 msgstr "Block Num è attivo"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:69
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:69
 msgid "Num lock is not active"
 msgstr " Block Num non è attivo"
 
-#: ../panel/applets/show-desktop/ShowDesktopApplet.vala:33
+#: ../src/panel/applets/show-desktop/ShowDesktopApplet.vala:33
 msgid "Toggle the desktop"
 msgstr "Mostra il desktop"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:101
+#: ../src/panel/applets/status/BluetoothIndicator.vala:101
 msgid "Bluetooth is disabled"
 msgstr "Bluetooth disattivato"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:105
+#: ../src/panel/applets/status/BluetoothIndicator.vala:105
 msgid "Bluetooth is active"
 msgstr "Bluetooth attivato"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:110
+#: ../src/panel/applets/status/BluetoothIndicator.vala:110
 #, c-format
 msgid "Connected to %d device"
 msgid_plural "Connected to %d devices"
 msgstr[0] "Connesso a %d dispositivo"
 msgstr[1] "Connesso a %d dispositivi"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:171
+#: ../src/panel/applets/status/BluetoothIndicator.vala:171
 msgid "Bluetooth Settings"
 msgstr "Impostazioni Bluetooth"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:172
+#: ../src/panel/applets/status/BluetoothIndicator.vala:172
 msgid "Send Files"
 msgstr "Invia File"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:173
+#: ../src/panel/applets/status/BluetoothIndicator.vala:173
 msgid "Bluetooth Airplane Mode"
 msgstr "Bluetooth in Modalità Aereo"
 
-#: ../panel/applets/status/PowerIndicator.vala:56
+#: ../src/panel/applets/status/PowerIndicator.vala:56
 msgid "Battery fully charged."
 msgstr "Batteria completamente carica."
 
-#: ../panel/applets/status/PowerIndicator.vala:59
+#: ../src/panel/applets/status/PowerIndicator.vala:59
 msgid "Unknown"
 msgstr "Sconosciuto"
 
 #. Set inner charging duration to hours:minutes
-#: ../panel/applets/status/PowerIndicator.vala:68
+#: ../src/panel/applets/status/PowerIndicator.vala:68
 msgid "Battery charging"
 msgstr "Batteria in carica"
 
-#: ../panel/applets/status/PowerIndicator.vala:73
+#: ../src/panel/applets/status/PowerIndicator.vala:73
 msgid "Battery remaining"
 msgstr "Batteria rimanente"
 
-#: ../panel/applets/status/PowerIndicator.vala:107
+#: ../src/panel/applets/status/PowerIndicator.vala:107
 msgid "Power settings"
-msgstr ""
+msgstr "Impostazioni alimentazione"
 
 #. User Menu Creation
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:95
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:95
 msgid "User"
-msgstr ""
+msgstr "Utente"
 
 #. Default to "User" and symbolic icon
 #. The rest
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:101
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:101
 msgid "Lock"
-msgstr ""
+msgstr "Blocca"
 
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:102
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:102
 msgid "Suspend"
-msgstr ""
+msgstr "Sospendi"
 
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:103
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:103
 msgid "Hibernate"
-msgstr ""
+msgstr "Iberna"
 
-#: ../wm/windowmenu.vala:124
+#: ../src/wm/windowmenu.vala:124
 msgid "Minimize"
 msgstr "Minimizza"
 
-#: ../wm/windowmenu.vala:129
+#: ../src/wm/windowmenu.vala:129
 msgid "Unmaximize"
 msgstr "Rimpicciolisci"
 
-#: ../wm/windowmenu.vala:134
+#: ../src/wm/windowmenu.vala:134
 msgid "Maximize"
 msgstr "Massimizza"
 
-#: ../wm/windowmenu.vala:139
+#: ../src/wm/windowmenu.vala:139
 msgid "Move"
 msgstr "Sposta"
 
-#: ../wm/windowmenu.vala:144
+#: ../src/wm/windowmenu.vala:144
 msgid "Resize"
 msgstr "Scala"
 
-#: ../wm/windowmenu.vala:149
+#: ../src/wm/windowmenu.vala:149
 msgid "Always On Top"
-msgstr "Sempre Davanti"
+msgstr "Sempre in primo piano"
 
-#: ../wm/windowmenu.vala:154
+#: ../src/wm/windowmenu.vala:154
 msgid "Close"
 msgstr "Chiudi"
 
-#: ../wm/wm.vala:515
+#: ../src/wm/wm.vala:519
 msgid "Change background"
 msgstr "Cambia lo sfondo"
 
-#: ../wm/wm.vala:524
+#: ../src/wm/wm.vala:528
 msgid "Settings"
 msgstr "Impostazioni"
 
+#. End BudgieWMDBUS
 #. End namespace
 #. * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
 #. *
@@ -453,119 +459,137 @@ msgstr "Impostazioni"
 #. *
 #. * vi: set shiftwidth=4 tabstop=4 expandtab:
 #. * :indentSize=4:tabSize=4:noTabs=true:
-#: ../panel/applets/clock/ClockApplet.plugin.in.h:1
+#: ../src/panel/applets/clock/ClockApplet.plugin.in.h:1
 msgid "Clock"
 msgstr "Orologio"
 
-#: ../panel/applets/show-desktop/ShowDesktopApplet.plugin.in.h:1
+#: ../src/panel/applets/show-desktop/ShowDesktopApplet.plugin.in.h:1
 msgid "Show Desktop Button"
 msgstr "Mostra il Pulsante Desktop"
 
-#: ../panel/applets/tasklist/TasklistApplet.plugin.in.h:1
+#: ../src/panel/applets/tasklist/TasklistApplet.plugin.in.h:1
 msgid "Task List"
 msgstr "Elenco delle Attività"
 
-#: ../panel/applets/icon-tasklist/IconTasklistApplet.plugin.in.h:1
+#: ../src/panel/applets/places-indicator/PlacesIndicator.plugin.in.h:1
+#: ../src/panel/applets/places-indicator/PlacesIndicator.vala:80
+#: ../src/panel/applets/places-indicator/PlacesSection.vala:32
+msgid "Places"
+msgstr "Posizioni"
+
+#: ../src/panel/applets/icon-tasklist/IconTasklistApplet.plugin.in.h:1
 msgid "Icon Task List"
 msgstr "Icona Elenco delle Attività"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.plugin.in.h:1
+#: ../src/panel/applets/lock-keys/LockKeysApplet.plugin.in.h:1
 msgid "Lock Keys Indicator"
 msgstr "Indicatore Lock Keys"
 
-#: ../panel/applets/spacer/SpacerApplet.plugin.in.h:1
+#: ../src/panel/applets/raven-trigger/RavenTriggerApplet.plugin.in.h:1
+msgid "Raven Sidebar Control"
+msgstr "Controllo Barra Laterale Raven"
+
+#: ../src/panel/applets/spacer/SpacerApplet.plugin.in.h:1
 msgid "Spacer"
 msgstr "Spaziatore"
 
-#: ../panel/applets/workspaces/WorkspacesApplet.plugin.in.h:1
+#: ../src/panel/applets/user-indicator/UserIndicator.plugin.in.h:1
+msgid "User Indicator"
+msgstr "Indicatore utente"
+
+#: ../src/panel/applets/workspaces/WorkspacesApplet.plugin.in.h:1
 msgid "Workspace Switcher"
 msgstr "Selettore Desktop Virtuali"
 
-#: ../panel/applets/tray/TrayApplet.plugin.in.h:1
+#: ../src/panel/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in.h:1
+msgid "Keyboard Layout Indicator"
+msgstr "Indicatore del layout della tastiera"
+
+#: ../src/panel/applets/tray/TrayApplet.plugin.in.h:1
 msgid "System Tray"
 msgstr "Area di Notifica"
 
-#: ../panel/applets/status/StatusApplet.plugin.in.h:1
+#: ../src/panel/applets/status/StatusApplet.plugin.in.h:1
 msgid "Status Indicator"
 msgstr "Indicatore di Stato"
 
-#: ../panel/applets/budgie-menu/BudgieMenu.plugin.in.h:1
+#: ../src/panel/applets/budgie-menu/BudgieMenu.plugin.in.h:1
 msgid "Budgie Menu"
 msgstr "Menú Budgie"
 
-#: ../panel/applets/separator/SeparatorApplet.plugin.in.h:1
+#: ../src/panel/applets/separator/SeparatorApplet.plugin.in.h:1
 msgid "Separator"
 msgstr "Separatore"
 
-#: ../panel/applets/places-indicator/MountItem.vala:23
-#: ../panel/applets/places-indicator/VolumeItem.vala:23
+#: ../src/panel/applets/places-indicator/MountItem.vala:23
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:23
 msgid "Removable devices"
-msgstr ""
+msgstr "Dispositivi removibili"
 
-#: ../panel/applets/places-indicator/MountItem.vala:25
-#: ../panel/applets/places-indicator/VolumeItem.vala:25
+#: ../src/panel/applets/places-indicator/MountItem.vala:25
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:25
 msgid "Local volumes"
-msgstr ""
+msgstr "Dischi locali"
 
-#: ../panel/applets/places-indicator/MountItem.vala:29
-#: ../panel/applets/places-indicator/VolumeItem.vala:29
+#: ../src/panel/applets/places-indicator/MountItem.vala:29
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:29
 msgid "Network folders"
-msgstr ""
+msgstr "Cartelle di rete"
 
-#: ../panel/applets/places-indicator/MountItem.vala:49
-#: ../panel/applets/places-indicator/VolumeItem.vala:46
+#: ../src/panel/applets/places-indicator/MountItem.vala:32
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:32
+msgid "Other"
+msgstr "Altro"
+
+#: ../src/panel/applets/places-indicator/MountItem.vala:52
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:49
 msgid "Eject"
-msgstr ""
+msgstr "Espelli"
 
-#: ../panel/applets/places-indicator/MountItem.vala:51
+#: ../src/panel/applets/places-indicator/MountItem.vala:54
 msgid "Unmount"
-msgstr ""
+msgstr "Smonta"
 
-#: ../panel/applets/places-indicator/MountItem.vala:54
-#: ../panel/applets/places-indicator/PlaceItem.vala:27
+#: ../src/panel/applets/places-indicator/MountItem.vala:57
+#: ../src/panel/applets/places-indicator/PlaceItem.vala:27
 #, c-format
 msgid "Open \"%s\""
-msgstr ""
+msgstr "Apri \"%s\""
 
-#: ../panel/applets/places-indicator/MountItem.vala:78
-#: ../panel/applets/places-indicator/VolumeItem.vala:53
+#: ../src/panel/applets/places-indicator/MountItem.vala:81
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:56
 msgid "You can now safely remove"
-msgstr ""
+msgstr "Ora puoi rimuoverlo in modo sicuro"
 
-#: ../panel/applets/places-indicator/PlacesIndicator.vala:80
-#: ../panel/applets/places-indicator/PlacesSection.vala:32
-msgid "Places"
-msgstr ""
-
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:139
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:139
 msgid "Nothing to display right now"
-msgstr ""
+msgstr "Nulla da visualizare ora"
 
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Mount some drives"
-msgstr ""
+msgstr "Monta delle unità"
 
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Enable more sections"
-msgstr ""
+msgstr "Abilita più sezioni"
 
-#: ../panel/applets/places-indicator/VolumeItem.vala:64
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:67
 #, c-format
 msgid "Mount and open \"%s\""
-msgstr ""
+msgstr "Monta e apri \"%s\""
 
-#: ../panel/applets/places-indicator/settings.ui.h:1
+#: ../src/panel/applets/places-indicator/settings.ui.h:1
 msgid "Show label"
-msgstr ""
+msgstr "Mostra le etichette "
 
-#: ../panel/applets/places-indicator/settings.ui.h:2
+#: ../src/panel/applets/places-indicator/settings.ui.h:2
 msgid "Show places"
-msgstr ""
+msgstr "Visualizza percorsi"
 
-#: ../panel/applets/places-indicator/settings.ui.h:3
+#: ../src/panel/applets/places-indicator/settings.ui.h:3
 msgid "Show removable drives"
-msgstr ""
+msgstr "Mostra le unità removibili"
 
-#: ../panel/applets/places-indicator/settings.ui.h:4
+#: ../src/panel/applets/places-indicator/settings.ui.h:4
 msgid "Show network folders"
-msgstr ""
+msgstr "Mostra le cartelle di rete"

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -3,133 +3,136 @@
 # This file is distributed under the same license as the PACKAGE package.
 # 
 # Translators:
-# BALLOON a.k.a. Fu-sen., 2016
-# BALLOON a.k.a. Fu-sen., 2015-2016
+# ふうせん Fu-sen. | BALLOON a.k.a. Fu-sen., 2016
+# ふうせん Fu-sen. | BALLOON a.k.a. Fu-sen., 2015-2016
+# ふうせん Fu-sen. | BALLOON a.k.a. Fu-sen., 2016
+# あわしろいくや <ikunya@gmail.com>, 2017
+# Nobuhiro Iwamatsu <iwamatsu@nigauri.org>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Budgie Desktop\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-21 08:11+0100\n"
-"PO-Revision-Date: 2016-10-22 01:33+0000\n"
-"Last-Translator: BALLOON a.k.a. Fu-sen.\n"
-"Language-Team: Japanese (Japan) (http://www.transifex.com/solus-project/budgie-desktop/language/ja_JP/)\n"
+"POT-Creation-Date: 2016-10-26 04:02+0100\n"
+"PO-Revision-Date: 2017-04-16 09:51+0000\n"
+"Last-Translator: あわしろいくや <ikunya@gmail.com>\n"
+"Language-Team: Japanese (Japan) (http://www.transifex.com/budgie-desktop/budgie-desktop/language/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../daemon/endsession.vala:167
+#: ../src/daemon/endsession.vala:167
 msgid "Log out"
 msgstr "ログアウト"
 
-#: ../daemon/endsession.vala:171
+#: ../src/daemon/endsession.vala:171
 msgid "Restart device"
 msgstr "デバイスの再起動"
 
-#: ../daemon/endsession.vala:183 ../daemon/endsession.ui.h:1
+#: ../src/daemon/endsession.vala:183 ../src/daemon/endsession.ui.h:1
 msgid "Power Off"
-msgstr "電源を切る"
+msgstr "電源オフ"
 
-#: ../raven/main_view.vala:72 ../raven/ui/panel.ui.h:7
+#: ../src/raven/main_view.vala:72 ../src/raven/ui/panel.ui.h:7
 msgid "Applets"
 msgstr "アプレット"
 
-#: ../raven/main_view.vala:75
-#: ../panel/applets/notifications/NotificationsApplet.plugin.in.h:1
+#: ../src/raven/main_view.vala:75
+#: ../src/panel/applets/notifications/NotificationsApplet.plugin.in.h:1
 msgid "Notifications"
 msgstr "通知"
 
-#: ../raven/settings_view.vala:266
+#: ../src/raven/settings_view.vala:266
 msgid "Top"
 msgstr "上"
 
-#: ../raven/settings_view.vala:268
+#: ../src/raven/settings_view.vala:268
 msgid "Bottom"
 msgstr "下"
 
-#: ../raven/settings_view.vala:376
+#: ../src/raven/settings_view.vala:376
 msgid "Top Panel"
 msgstr "上パネル"
 
-#: ../raven/settings_view.vala:378
+#: ../src/raven/settings_view.vala:378
 msgid "Right Panel"
 msgstr "右パネル"
 
-#: ../raven/settings_view.vala:380
+#: ../src/raven/settings_view.vala:380
 msgid "Left Panel"
 msgstr "左パネル"
 
-#: ../raven/settings_view.vala:382
+#: ../src/raven/settings_view.vala:382
 msgid "Bottom Panel"
 msgstr "下パネル"
 
-#: ../raven/settings_view.vala:616
+#: ../src/raven/settings_view.vala:616
 msgid "Start"
-msgstr "左・上"
+msgstr "始点"
 
-#: ../raven/settings_view.vala:619
+#: ../src/raven/settings_view.vala:619
 msgid "Center"
 msgstr "中央"
 
-#: ../raven/settings_view.vala:622
+#: ../src/raven/settings_view.vala:622
 msgid "End"
-msgstr "右・下"
+msgstr "終点"
 
 #. Appearance expander
-#: ../raven/settings_view.vala:960
+#: ../src/raven/settings_view.vala:960
 msgid "Appearance"
 msgstr "外観"
 
-#: ../raven/settings_view.vala:967
+#: ../src/raven/settings_view.vala:967
 msgid "Background"
 msgstr "背景"
 
-#: ../raven/settings_view.vala:974
+#: ../src/raven/settings_view.vala:974
 msgid "Fonts"
 msgstr "フォント"
 
-#: ../raven/settings_view.vala:980
+#: ../src/raven/settings_view.vala:980
 msgid "Windows"
-msgstr "ウインドウ"
+msgstr "ウィンドウ"
 
-#: ../raven/settings_view.vala:984
+#: ../src/raven/settings_view.vala:984
 msgid "General"
-msgstr "基本設定"
+msgstr "全般"
 
-#: ../raven/settings_view.vala:995 ../raven/settings_view.vala:996
+#: ../src/raven/settings_view.vala:995 ../src/raven/settings_view.vala:996
 msgid "Panel"
 msgstr "パネル"
 
-#: ../raven/notifications_view.vala:74
+#: ../src/raven/notifications_view.vala:74
 msgid "Nothing to see here"
-msgstr "表示する内容はありません"
+msgstr "表示することはありません"
 
-#: ../raven/notifications_view.vala:516
-#: ../panel/applets/notifications/NotificationsApplet.vala:75
+#: ../src/raven/notifications_view.vala:516
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:75
 #, c-format
 msgid "%u unread notifications"
-msgstr "未読通知 %u"
+msgstr "%u 個の未読通知があります"
 
-#: ../raven/notifications_view.vala:518
-#: ../panel/applets/notifications/NotificationsApplet.vala:77
+#: ../src/raven/notifications_view.vala:518
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:77
 msgid "1 unread notification"
-msgstr "未読通知 1"
+msgstr "1個の未読通知があります"
 
-#: ../raven/notifications_view.vala:520
-#: ../panel/applets/notifications/NotificationsApplet.vala:79
+#: ../src/raven/notifications_view.vala:520
+#: ../src/panel/applets/notifications/NotificationsApplet.vala:79
 msgid "No unread notifications"
-msgstr "未読通知 なし"
+msgstr "未読通知はありません"
 
-#: ../raven/notifications_view.vala:646
+#: ../src/raven/notifications_view.vala:646
 msgid "No new notifications"
-msgstr "新たな通知 なし"
+msgstr "新しい通知はありません"
 
-#: ../raven/sound.vala:78
+#: ../src/raven/sound.vala:78
 msgid "Output"
 msgstr "出力"
 
-#: ../raven/sound.vala:95
+#: ../src/raven/sound.vala:95
 msgid "Input"
 msgstr "入力"
 
@@ -144,300 +147,301 @@ msgstr "入力"
 #. *
 #. * vi: set shiftwidth=4 tabstop=4 expandtab:
 #. * :indentSize=4:tabSize=4:noTabs=true:
-#: ../panel/applets/spacer/settings.ui.h:1
+#: ../src/panel/applets/spacer/settings.ui.h:1
 msgid "Spacer size"
-msgstr "余白のサイズ"
+msgstr "スペーサーの幅"
 
-#: ../raven/ui/settings.ui.h:1
+#: ../src/raven/ui/settings.ui.h:1
 msgid "Budgie Settings"
-msgstr "Budgie 設定"
+msgstr "Budgie設定"
 
-#: ../raven/ui/settings.ui.h:2
+#: ../src/raven/ui/settings.ui.h:2
 msgid "Exit"
 msgstr "終了"
 
-#: ../raven/ui/applets.ui.h:1
+#: ../src/raven/ui/applets.ui.h:1
 msgid "Add new applet"
-msgstr "新たなアプレットを追加"
+msgstr "新しいアプレットの追加"
 
-#: ../raven/ui/appearance.ui.h:1
+#: ../src/raven/ui/appearance.ui.h:1
 msgid "Use the dark theme"
-msgstr "ダークテーマを使用する"
+msgstr "ダークテーマの使用"
 
-#: ../raven/ui/appearance.ui.h:2
+#: ../src/raven/ui/appearance.ui.h:2
 msgid "Dark theme"
 msgstr "ダークテーマ"
 
-#: ../raven/ui/appearance.ui.h:3
+#: ../src/raven/ui/appearance.ui.h:3
 msgid "Select a GTK+ theme"
-msgstr "GTK+ テーマを選択"
+msgstr "GTK+ テーマの選択"
 
-#: ../raven/ui/appearance.ui.h:4
+#: ../src/raven/ui/appearance.ui.h:4
 msgid "Widget Theme"
 msgstr "ウィジェットテーマ"
 
-#: ../raven/ui/appearance.ui.h:5
+#: ../src/raven/ui/appearance.ui.h:5
 msgid "Select an icon theme"
-msgstr "アイコンテーマを選択"
+msgstr "アイコンテーマの選択"
 
-#: ../raven/ui/appearance.ui.h:6
+#: ../src/raven/ui/appearance.ui.h:6
 msgid "Icon Theme"
 msgstr "アイコンテーマ"
 
-#: ../raven/ui/appearance.ui.h:7
+#: ../src/raven/ui/appearance.ui.h:7
 msgid "Override defaults"
 msgstr "デフォルトを無効にする"
 
-#: ../raven/ui/appearance.ui.h:8
+#: ../src/raven/ui/appearance.ui.h:8
 msgid "Built-in theme"
 msgstr "ビルドインテーマ"
 
-#: ../raven/ui/appearance.ui.h:9
+#: ../src/raven/ui/appearance.ui.h:9
 msgid "Select a cursor theme"
-msgstr "カーソルテーマを選択"
+msgstr "カーソルテーマの選択"
 
-#: ../raven/ui/appearance.ui.h:10
+#: ../src/raven/ui/appearance.ui.h:10
 msgid "Cursor Theme"
 msgstr "カーソルテーマ"
 
-#: ../raven/ui/panel.ui.h:1
+#: ../src/raven/ui/panel.ui.h:1
 msgid "Manage Panels"
 msgstr "パネルの管理"
 
-#: ../raven/ui/panel.ui.h:2
+#: ../src/raven/ui/panel.ui.h:2
 msgid "Position"
 msgstr "位置"
 
-#: ../raven/ui/panel.ui.h:3
+#: ../src/raven/ui/panel.ui.h:3
 msgid "Size"
-msgstr "サイズ"
+msgstr "大きさ"
 
-#: ../raven/ui/panel.ui.h:4
+#: ../src/raven/ui/panel.ui.h:4
 msgid "Shadow"
 msgstr "影"
 
-#: ../raven/ui/panel.ui.h:5
+#: ../src/raven/ui/panel.ui.h:5
 msgid "Autohide policy"
-msgstr "ポリシーを自動で隠す"
+msgstr "自動的に隠す"
 
-#: ../raven/ui/panel.ui.h:6
+#: ../src/raven/ui/panel.ui.h:6
 msgid "Stylize regions"
-msgstr "領域に収める"
+msgstr "領域に合わせる"
 
-#: ../raven/ui/background.ui.h:1
+#: ../src/raven/ui/background.ui.h:1
 msgid "Show desktop icons"
 msgstr "デスクトップアイコンの表示"
 
-#: ../raven/ui/background.ui.h:2
+#: ../src/raven/ui/background.ui.h:2
 msgid "Desktop Icons"
 msgstr "デスクトップアイコン"
 
-#: ../raven/ui/fonts.ui.h:1
+#: ../src/raven/ui/fonts.ui.h:1
 msgid "Window Titles"
-msgstr "ウインドウタイトル"
+msgstr "ウィンドウタイトル"
 
-#: ../raven/ui/fonts.ui.h:2
+#: ../src/raven/ui/fonts.ui.h:2
 msgid "Interface"
-msgstr "インターフェイス"
+msgstr "インターフェース"
 
-#: ../raven/ui/fonts.ui.h:3
+#: ../src/raven/ui/fonts.ui.h:3
 msgid "Documents"
 msgstr "ドキュメント"
 
-#: ../raven/ui/fonts.ui.h:4
+#: ../src/raven/ui/fonts.ui.h:4
 msgid "Monospace"
-msgstr "等幅フォント"
+msgstr "Monospace"
 
-#: ../raven/ui/wm.ui.h:1
+#: ../src/raven/ui/wm.ui.h:1
 msgid "Disable unredirect of fullscreen windows"
-msgstr "フルスクリーンウィンドウのアンリダイレクトを無効にします"
+msgstr "全画面ウィンドウのアンリダイレクトを無効にする"
 
-#: ../raven/ui/wm.ui.h:2
+#: ../src/raven/ui/wm.ui.h:2
 msgid "Disable unredirect"
 msgstr "アンリダイレクトの無効"
 
-#: ../raven/ui/wm.ui.h:3
+#: ../src/raven/ui/wm.ui.h:3
 msgid "Change the layout of the window buttons"
-msgstr "ウインドウボタンのレイアウトを変更します"
+msgstr "ウィンドウボタンのレイアウトを変更する"
 
-#: ../raven/ui/wm.ui.h:4
+#: ../src/raven/ui/wm.ui.h:4
 msgid "Button layout"
 msgstr "ボタンレイアウト"
 
-#: ../session/budgie-desktop.desktop.in.in.h:1
-#: ../session/budgie-desktop.session.in.in.h:1
+#: ../src/session/budgie-desktop.desktop.in.in.h:1
+#: ../src/session/budgie-desktop.session.in.in.h:1
 msgid "Budgie Desktop"
-msgstr "Budgie Desktop"
+msgstr "Budgieデスクトップ"
 
-#: ../session/budgie-desktop.desktop.in.in.h:2
+#: ../src/session/budgie-desktop.desktop.in.in.h:2
 msgid "This session logs you into the Budgie Desktop"
-msgstr "このセッションは Budgie Desktop へログインします"
+msgstr "このセッションではBudgieデスクトップにログインします"
 
-#: ../daemon/endsession.ui.h:2
+#: ../src/daemon/endsession.ui.h:2
 msgid "Are you sure you want to end your session?"
-msgstr "セッションを終了してよろしいですか？"
+msgstr "本当にこのセッションを終了しますか？"
 
-#: ../daemon/endsession.ui.h:3
+#: ../src/daemon/endsession.ui.h:3
 msgid "Cancel"
 msgstr "キャンセル"
 
 #. IndicatorItem switch_user_menu = new IndicatorItem(_("Switch User"),
 #. "network-transmit-receive-symbolic", false);
-#: ../daemon/endsession.ui.h:4
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:179
+#: ../src/daemon/endsession.ui.h:4
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:179
 msgid "Logout"
 msgstr "ログアウト"
 
-#: ../daemon/endsession.ui.h:5
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:104
+#: ../src/daemon/endsession.ui.h:5
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:104
 msgid "Restart"
 msgstr "再起動"
 
-#: ../daemon/endsession.ui.h:6
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:105
+#: ../src/daemon/endsession.ui.h:6
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:105
 msgid "Shutdown"
 msgstr "シャットダウン"
 
-#: ../panel/applets/clock/ClockApplet.vala:55
+#: ../src/panel/applets/clock/ClockApplet.vala:55
 msgid "Time and date settings"
-msgstr "日時の設定"
+msgstr "日付と時刻の設定"
 
-#: ../panel/applets/clock/ClockApplet.vala:56
+#: ../src/panel/applets/clock/ClockApplet.vala:56
 msgid "Calendar"
 msgstr "カレンダー"
 
-#: ../panel/applets/icon-tasklist/Buttons.vala:90
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:90
 msgid "Pin to panel"
-msgstr "パネルに固定する"
+msgstr "パネルに留める"
 
-#: ../panel/applets/icon-tasklist/Buttons.vala:91
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:91
+#: ../src/panel/applets/icon-tasklist/Buttons.vala:455
 msgid "Unpin from panel"
-msgstr "パネルから固定を解除する"
+msgstr "パネルから分離する"
 
 #. Special case, "All"
-#: ../panel/applets/budgie-menu/BudgieMenuWindow.vala:31
+#: ../src/panel/applets/budgie-menu/BudgieMenuWindow.vala:31
 msgid "All"
 msgstr "すべて"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:53
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:53
 msgid "Caps lock is active"
-msgstr "Caps lock オン"
+msgstr "Caps lockが有効です"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:56
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:56
 msgid "Caps lock is not active"
-msgstr "Caps lock オフ"
+msgstr "Caps lockが無効です"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:66
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:66
 msgid "Num lock is active"
-msgstr "Num lock オン"
+msgstr "Num lockが有効です"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.vala:69
+#: ../src/panel/applets/lock-keys/LockKeysApplet.vala:69
 msgid "Num lock is not active"
-msgstr "Num lock オフ "
+msgstr "Num lockが無効です"
 
-#: ../panel/applets/show-desktop/ShowDesktopApplet.vala:33
+#: ../src/panel/applets/show-desktop/ShowDesktopApplet.vala:33
 msgid "Toggle the desktop"
-msgstr "デスクトップの切替"
+msgstr "デスクトップの切り替え"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:101
+#: ../src/panel/applets/status/BluetoothIndicator.vala:101
 msgid "Bluetooth is disabled"
-msgstr "Blurtooth 無効"
+msgstr "Bluetoothが無効です"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:105
+#: ../src/panel/applets/status/BluetoothIndicator.vala:105
 msgid "Bluetooth is active"
-msgstr "Bluetooth 有効"
+msgstr "Bluetoothが有効です"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:110
+#: ../src/panel/applets/status/BluetoothIndicator.vala:110
 #, c-format
 msgid "Connected to %d device"
 msgid_plural "Connected to %d devices"
-msgstr[0] "接続 %d デバイス"
+msgstr[0] "\"%d デバイスが接続されました"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:171
+#: ../src/panel/applets/status/BluetoothIndicator.vala:171
 msgid "Bluetooth Settings"
-msgstr "Bluetooth 設定"
+msgstr "Bluetooth設定"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:172
+#: ../src/panel/applets/status/BluetoothIndicator.vala:172
 msgid "Send Files"
-msgstr "ファイル送信"
+msgstr "ファイルを送信する"
 
-#: ../panel/applets/status/BluetoothIndicator.vala:173
+#: ../src/panel/applets/status/BluetoothIndicator.vala:173
 msgid "Bluetooth Airplane Mode"
-msgstr "Bluetooth 機内モード"
+msgstr "Bluetooth機内モード"
 
-#: ../panel/applets/status/PowerIndicator.vala:56
+#: ../src/panel/applets/status/PowerIndicator.vala:56
 msgid "Battery fully charged."
-msgstr "バッテリー充電完了"
+msgstr "バッテリーは満充電です。"
 
-#: ../panel/applets/status/PowerIndicator.vala:59
+#: ../src/panel/applets/status/PowerIndicator.vala:59
 msgid "Unknown"
 msgstr "不明"
 
 #. Set inner charging duration to hours:minutes
-#: ../panel/applets/status/PowerIndicator.vala:68
+#: ../src/panel/applets/status/PowerIndicator.vala:68
 msgid "Battery charging"
 msgstr "バッテリー充電中"
 
-#: ../panel/applets/status/PowerIndicator.vala:73
+#: ../src/panel/applets/status/PowerIndicator.vala:73
 msgid "Battery remaining"
-msgstr "バッテリー残り"
+msgstr "バッテリーの残り時間"
 
-#: ../panel/applets/status/PowerIndicator.vala:107
+#: ../src/panel/applets/status/PowerIndicator.vala:107
 msgid "Power settings"
 msgstr "電源設定"
 
 #. User Menu Creation
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:95
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:95
 msgid "User"
 msgstr "ユーザー"
 
 #. Default to "User" and symbolic icon
 #. The rest
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:101
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:101
 msgid "Lock"
 msgstr "ロック"
 
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:102
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:102
 msgid "Suspend"
 msgstr "サスペンド"
 
-#: ../panel/applets/user-indicator/UserIndicatorWindow.vala:103
+#: ../src/panel/applets/user-indicator/UserIndicatorWindow.vala:103
 msgid "Hibernate"
 msgstr "ハイバネート"
 
-#: ../wm/windowmenu.vala:124
+#: ../src/wm/windowmenu.vala:124
 msgid "Minimize"
 msgstr "最小化"
 
-#: ../wm/windowmenu.vala:129
+#: ../src/wm/windowmenu.vala:129
 msgid "Unmaximize"
 msgstr "最大化の解除"
 
-#: ../wm/windowmenu.vala:134
+#: ../src/wm/windowmenu.vala:134
 msgid "Maximize"
 msgstr "最大化"
 
-#: ../wm/windowmenu.vala:139
+#: ../src/wm/windowmenu.vala:139
 msgid "Move"
 msgstr "移動"
 
-#: ../wm/windowmenu.vala:144
+#: ../src/wm/windowmenu.vala:144
 msgid "Resize"
 msgstr "サイズ変更"
 
-#: ../wm/windowmenu.vala:149
+#: ../src/wm/windowmenu.vala:149
 msgid "Always On Top"
-msgstr "常に上へ表示"
+msgstr "常に上に表示"
 
-#: ../wm/windowmenu.vala:154
+#: ../src/wm/windowmenu.vala:154
 msgid "Close"
 msgstr "閉じる"
 
-#: ../wm/wm.vala:519
+#: ../src/wm/wm.vala:519
 msgid "Change background"
-msgstr "背景の変更"
+msgstr "壁紙の変更"
 
-#: ../wm/wm.vala:528
+#: ../src/wm/wm.vala:528
 msgid "Settings"
 msgstr "設定"
 
@@ -453,137 +457,137 @@ msgstr "設定"
 #. *
 #. * vi: set shiftwidth=4 tabstop=4 expandtab:
 #. * :indentSize=4:tabSize=4:noTabs=true:
-#: ../panel/applets/clock/ClockApplet.plugin.in.h:1
+#: ../src/panel/applets/clock/ClockApplet.plugin.in.h:1
 msgid "Clock"
 msgstr "時計"
 
-#: ../panel/applets/show-desktop/ShowDesktopApplet.plugin.in.h:1
+#: ../src/panel/applets/show-desktop/ShowDesktopApplet.plugin.in.h:1
 msgid "Show Desktop Button"
 msgstr "デスクトップボタンの表示"
 
-#: ../panel/applets/tasklist/TasklistApplet.plugin.in.h:1
+#: ../src/panel/applets/tasklist/TasklistApplet.plugin.in.h:1
 msgid "Task List"
-msgstr "タスク一覧"
+msgstr "タスクリスト"
 
-#: ../panel/applets/places-indicator/PlacesIndicator.plugin.in.h:1
-#: ../panel/applets/places-indicator/PlacesIndicator.vala:80
-#: ../panel/applets/places-indicator/PlacesSection.vala:32
+#: ../src/panel/applets/places-indicator/PlacesIndicator.plugin.in.h:1
+#: ../src/panel/applets/places-indicator/PlacesIndicator.vala:80
+#: ../src/panel/applets/places-indicator/PlacesSection.vala:32
 msgid "Places"
 msgstr "場所"
 
-#: ../panel/applets/icon-tasklist/IconTasklistApplet.plugin.in.h:1
+#: ../src/panel/applets/icon-tasklist/IconTasklistApplet.plugin.in.h:1
 msgid "Icon Task List"
-msgstr "タスク一覧アイコン"
+msgstr "アイコンのタスクリスト"
 
-#: ../panel/applets/lock-keys/LockKeysApplet.plugin.in.h:1
+#: ../src/panel/applets/lock-keys/LockKeysApplet.plugin.in.h:1
 msgid "Lock Keys Indicator"
-msgstr "キーロック表示"
+msgstr "ロックキーインジケーター"
 
-#: ../panel/applets/raven-trigger/RavenTriggerApplet.plugin.in.h:1
+#: ../src/panel/applets/raven-trigger/RavenTriggerApplet.plugin.in.h:1
 msgid "Raven Sidebar Control"
-msgstr "Ravan サイドバー管理"
+msgstr "Ravenサイドバーの設定"
 
-#: ../panel/applets/spacer/SpacerApplet.plugin.in.h:1
+#: ../src/panel/applets/spacer/SpacerApplet.plugin.in.h:1
 msgid "Spacer"
-msgstr "余白"
+msgstr "スペーサー"
 
-#: ../panel/applets/user-indicator/UserIndicator.plugin.in.h:1
+#: ../src/panel/applets/user-indicator/UserIndicator.plugin.in.h:1
 msgid "User Indicator"
-msgstr "ユーザーインジケータ"
+msgstr "ユーザーインジケーター"
 
-#: ../panel/applets/workspaces/WorkspacesApplet.plugin.in.h:1
+#: ../src/panel/applets/workspaces/WorkspacesApplet.plugin.in.h:1
 msgid "Workspace Switcher"
-msgstr "ワークスペースの切替"
+msgstr "ワークスペースの切替え"
 
-#: ../panel/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in.h:1
+#: ../src/panel/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in.h:1
 msgid "Keyboard Layout Indicator"
-msgstr "キーボードレイアウトインジケータ"
+msgstr "キーボードレイアウトインジケーター"
 
-#: ../panel/applets/tray/TrayApplet.plugin.in.h:1
+#: ../src/panel/applets/tray/TrayApplet.plugin.in.h:1
 msgid "System Tray"
 msgstr "システムトレイ"
 
-#: ../panel/applets/status/StatusApplet.plugin.in.h:1
+#: ../src/panel/applets/status/StatusApplet.plugin.in.h:1
 msgid "Status Indicator"
-msgstr "ステータス通知"
+msgstr "ステータスインジケーター"
 
-#: ../panel/applets/budgie-menu/BudgieMenu.plugin.in.h:1
+#: ../src/panel/applets/budgie-menu/BudgieMenu.plugin.in.h:1
 msgid "Budgie Menu"
-msgstr "Budgie メニュー"
+msgstr "Budgieメニュー"
 
-#: ../panel/applets/separator/SeparatorApplet.plugin.in.h:1
+#: ../src/panel/applets/separator/SeparatorApplet.plugin.in.h:1
 msgid "Separator"
-msgstr "区切り"
+msgstr "セパレーター"
 
-#: ../panel/applets/places-indicator/MountItem.vala:23
-#: ../panel/applets/places-indicator/VolumeItem.vala:23
+#: ../src/panel/applets/places-indicator/MountItem.vala:23
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:23
 msgid "Removable devices"
 msgstr "リムーバブルデバイス"
 
-#: ../panel/applets/places-indicator/MountItem.vala:25
-#: ../panel/applets/places-indicator/VolumeItem.vala:25
+#: ../src/panel/applets/places-indicator/MountItem.vala:25
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:25
 msgid "Local volumes"
-msgstr "ローカルボジューム"
+msgstr "ローカルボリューム"
 
-#: ../panel/applets/places-indicator/MountItem.vala:29
-#: ../panel/applets/places-indicator/VolumeItem.vala:29
+#: ../src/panel/applets/places-indicator/MountItem.vala:29
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:29
 msgid "Network folders"
 msgstr "ネットワークフォルダー"
 
-#: ../panel/applets/places-indicator/MountItem.vala:32
-#: ../panel/applets/places-indicator/VolumeItem.vala:32
+#: ../src/panel/applets/places-indicator/MountItem.vala:32
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:32
 msgid "Other"
 msgstr "その他"
 
-#: ../panel/applets/places-indicator/MountItem.vala:52
-#: ../panel/applets/places-indicator/VolumeItem.vala:49
+#: ../src/panel/applets/places-indicator/MountItem.vala:52
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:49
 msgid "Eject"
 msgstr "取り出し"
 
-#: ../panel/applets/places-indicator/MountItem.vala:54
+#: ../src/panel/applets/places-indicator/MountItem.vala:54
 msgid "Unmount"
-msgstr "マウント解除"
+msgstr "アンマウント"
 
-#: ../panel/applets/places-indicator/MountItem.vala:57
-#: ../panel/applets/places-indicator/PlaceItem.vala:27
+#: ../src/panel/applets/places-indicator/MountItem.vala:57
+#: ../src/panel/applets/places-indicator/PlaceItem.vala:27
 #, c-format
 msgid "Open \"%s\""
 msgstr "\"%s\" を開く"
 
-#: ../panel/applets/places-indicator/MountItem.vala:81
-#: ../panel/applets/places-indicator/VolumeItem.vala:56
+#: ../src/panel/applets/places-indicator/MountItem.vala:81
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:56
 msgid "You can now safely remove"
-msgstr "安全に取り出す事ができます"
+msgstr "安全に取り外せます"
 
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:139
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:139
 msgid "Nothing to display right now"
-msgstr "今表示するものが何もありません"
+msgstr "表示するものはありません"
 
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Mount some drives"
-msgstr "特定ドライブのマウント"
+msgstr "ドライブをマウントしました"
 
-#: ../panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
+#: ../src/panel/applets/places-indicator/PlacesIndicatorWindow.vala:143
 msgid "Enable more sections"
-msgstr "複数のセッションを有効にする"
+msgstr "ほかのセクションも有効にする"
 
-#: ../panel/applets/places-indicator/VolumeItem.vala:67
+#: ../src/panel/applets/places-indicator/VolumeItem.vala:67
 #, c-format
 msgid "Mount and open \"%s\""
-msgstr "\"%s\" をマウントし開く"
+msgstr "マウントして \\\"%s\\\" を開く"
 
-#: ../panel/applets/places-indicator/settings.ui.h:1
+#: ../src/panel/applets/places-indicator/settings.ui.h:1
 msgid "Show label"
-msgstr "ラベルを表示"
+msgstr "ラベルの表示"
 
-#: ../panel/applets/places-indicator/settings.ui.h:2
+#: ../src/panel/applets/places-indicator/settings.ui.h:2
 msgid "Show places"
-msgstr "場所を表示"
+msgstr "場所の表示"
 
-#: ../panel/applets/places-indicator/settings.ui.h:3
+#: ../src/panel/applets/places-indicator/settings.ui.h:3
 msgid "Show removable drives"
-msgstr "リブーバブルドライブを表示"
+msgstr "リムーバブルドライブの表示"
 
-#: ../panel/applets/places-indicator/settings.ui.h:4
+#: ../src/panel/applets/places-indicator/settings.ui.h:4
 msgid "Show network folders"
-msgstr "ネットワークフォルダーを表示"
+msgstr "ネットワークフォルダーの表示"

--- a/po/lt.po
+++ b/po/lt.po
@@ -4,15 +4,15 @@
 # 
 # Translators:
 # John Doe <voidboxmail@gmail.com>, 2015
-# Moo, 2015-2016
+# Moo, 2015-2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Budgie Desktop\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-26 04:02+0100\n"
-"PO-Revision-Date: 2016-11-03 23:31+0000\n"
+"PO-Revision-Date: 2017-04-10 15:31+0000\n"
 "Last-Translator: Moo\n"
-"Language-Team: Lithuanian (http://www.transifex.com/solus-project/budgie-desktop/language/lt/)\n"
+"Language-Team: Lithuanian (http://www.transifex.com/budgie-desktop/budgie-desktop/language/lt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -271,7 +271,7 @@ msgstr "Budgie darbalaukis"
 
 #: ../src/session/budgie-desktop.desktop.in.in.h:2
 msgid "This session logs you into the Budgie Desktop"
-msgstr "Ši sesija įkels jus į Budgie darbalaukį"
+msgstr "Šis seansas prijungs jus į Budgie darbalaukį"
 
 #: ../src/daemon/endsession.ui.h:2
 msgid "Are you sure you want to end your session?"

--- a/src/applets/budgie-menu/BudgieMenu.plugin.in
+++ b/src/applets/budgie-menu/BudgieMenu.plugin.in
@@ -3,6 +3,6 @@ Module=budgiemenuapplet.so
 Name=Budgie Menu
 _Description=Budgie Menu
 Authors=Ikey Doherty
-Copyright=Copyright © 2014 Ikey Doherty
+Copyright=Copyright © 2014-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=view-grid-symbolic

--- a/src/applets/budgie-menu/BudgieMenu.vala
+++ b/src/applets/budgie-menu/BudgieMenu.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/applets/budgie-menu/BudgieMenuWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/clock/ClockApplet.plugin.in
+++ b/src/applets/clock/ClockApplet.plugin.in
@@ -3,6 +3,6 @@ Module=clockapplet.so
 Name=Clock
 _Description=Clock
 Authors=Ikey Doherty
-Copyright=Copyright © 2014 Ikey Doherty
+Copyright=Copyright © 2014-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=clock-applet-symbolic

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2014-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2014-2016 Ikey Doherty <ikey@solus-project.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -48,8 +48,10 @@ public class ClockApplet : Budgie.Applet
     {
         widget = new Gtk.EventBox();
         clock = new Gtk.Label("");
+        clock.valign = Gtk.Align.CENTER;
         time = new DateTime.now_local();
         widget.add(clock);
+        margin_bottom = 2;
 
         var menu = new GLib.Menu();
         menu.append(_("Time and date settings"), "clock.time_and_date");

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -199,6 +199,9 @@ public class ClockApplet : Budgie.Applet
                 clock_date.set_state(new Variant.boolean(show_date));
                 break;
         }
+        if (get_toplevel() != null) {
+            get_toplevel().queue_draw();
+        }
         /* Lazy update on next clock sync */
     }
 

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -44,6 +44,10 @@ public class ClockApplet : Budgie.Applet
 
     private unowned Budgie.PopoverManager? manager = null;
 
+    SimpleAction? clock_seconds = null;
+    SimpleAction? clock_date = null;
+    SimpleAction? clock_format = null;
+
     public ClockApplet()
     {
         widget = new Gtk.EventBox();
@@ -56,6 +60,12 @@ public class ClockApplet : Budgie.Applet
         var menu = new GLib.Menu();
         menu.append(_("Time and date settings"), "clock.time_and_date");
         menu.append(_("Calendar"), "clock.calendar");
+
+        var menu_settings = new GLib.Menu();
+        menu_settings.append(_("Show date"), "clock.show_date");
+        menu_settings.append(_("Show seconds"), "clock.show_seconds");
+        menu_settings.append(_("Use 24 hour time"), "clock.format");
+        menu.append_submenu(_("Preferences"), menu_settings);
         popover = new Gtk.Popover.from_model(widget, menu);
 
         popover.get_child().show_all();
@@ -76,9 +86,6 @@ public class ClockApplet : Budgie.Applet
 
         settings = new Settings("org.gnome.desktop.interface");
         settings.changed.connect(on_settings_change);
-        on_settings_change("clock-format");
-        on_settings_change("clock-show-seconds");
-        on_settings_change("clock-show-date");
 
         var group = new GLib.SimpleActionGroup();
         var date = new GLib.SimpleAction("time_and_date", null);
@@ -90,6 +97,37 @@ public class ClockApplet : Budgie.Applet
         var monitor = AppInfoMonitor.get();
         monitor.changed.connect(update_cal);
 
+        /* Sort out the toggles */
+        clock_seconds = new GLib.SimpleAction.stateful("show_seconds", null, new Variant.boolean(true));
+        clock_seconds.activate.connect(()=> {
+            this.settings.set_boolean("clock-show-seconds", !this.settings.get_boolean("clock-show-seconds"));
+            Idle.add(()=> {
+                this.update_clock();
+                return false;
+            });
+        });
+        clock_date = new GLib.SimpleAction.stateful("show_date", null, new Variant.boolean(true));
+        clock_date.activate.connect(()=> {
+            this.settings.set_boolean("clock-show-date", !this.settings.get_boolean("clock-show-date"));
+            Idle.add(()=> {
+                this.update_clock();
+                return false;
+            });
+        });
+        clock_format = new GLib.SimpleAction.stateful("format", null, new Variant.boolean(true));
+        clock_format.activate.connect(()=> {
+            ClockFormat f = (ClockFormat)settings.get_enum("clock-format");
+            ClockFormat newf = f == ClockFormat.TWELVE ? ClockFormat.TWENTYFOUR : ClockFormat.TWELVE;
+            this.settings.set_enum("clock-format", newf);
+            Idle.add(()=> {
+                this.update_clock();
+                return false;
+            });
+        });
+        group.add_action(clock_seconds);
+        group.add_action(clock_date);
+        group.add_action(clock_format);
+
         this.insert_action_group("clock", group);
         cal = new GLib.SimpleAction("calendar", null);
         cal.set_enabled(calprov != null);
@@ -100,6 +138,9 @@ public class ClockApplet : Budgie.Applet
 
         update_clock();
         add(widget);
+        on_settings_change("clock-format");
+        on_settings_change("clock-show-seconds");
+        on_settings_change("clock-show-date");
         show_all();
     }
 
@@ -147,12 +188,15 @@ public class ClockApplet : Budgie.Applet
             case "clock-format":
                 ClockFormat f = (ClockFormat)settings.get_enum(key);
                 ampm = f == ClockFormat.TWELVE;
+                clock_format.set_state(new Variant.boolean(f == ClockFormat.TWENTYFOUR));
                 break;
             case "clock-show-seconds":
                 show_seconds = settings.get_boolean(key);
+                clock_seconds.set_state(new Variant.boolean(show_seconds));
                 break;
             case "clock-show-date":
                 show_date = settings.get_boolean(key);
+                clock_date.set_state(new Variant.boolean(show_date));
                 break;
         }
         /* Lazy update on next clock sync */

--- a/src/applets/icon-tasklist/AppSystem.vala
+++ b/src/applets/icon-tasklist/AppSystem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2014-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2014-2016 Ikey Doherty <ikey@solus-project.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/icon-tasklist/AppSystem.vala
+++ b/src/applets/icon-tasklist/AppSystem.vala
@@ -32,6 +32,7 @@ public class AppSystem : GLib.Object
         simpletons["code - oss"] = "vscode-oss";
         simpletons["code"] = "vscode";
         simpletons["psppire"] = "pspp";
+        simpletons["gnome-twitch"] = "com.vinszent.gnometwitch";
 
         derpers = new string[] {
             "atom",

--- a/src/applets/icon-tasklist/Buttons.vala
+++ b/src/applets/icon-tasklist/Buttons.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2014-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2014-2016 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/icon-tasklist/IconTasklistApplet.plugin.in
+++ b/src/applets/icon-tasklist/IconTasklistApplet.plugin.in
@@ -3,6 +3,6 @@ Module=icontasklistapplet.so
 Name=Icon Task List
 _Description=Icon Task List
 Authors=Ikey Doherty
-Copyright=Copyright © 2015 Ikey Doherty
+Copyright=Copyright © 2015-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=icon-task-list-symbolic

--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in
+++ b/src/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in
@@ -3,6 +3,6 @@ Module=keyboardlayoutapplet.so
 Name=Keyboard Layout
 _Description=Keyboard Layout Indicator
 Authors=Ikey Doherty
-Copyright=Copyright © 2016 Ikey Doherty
+Copyright=Copyright © 2016-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=input-keyboard-symbolic

--- a/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
+++ b/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/lock-keys/LockKeysApplet.plugin.in
+++ b/src/applets/lock-keys/LockKeysApplet.plugin.in
@@ -3,6 +3,6 @@ Module=lockkeysapplet.so
 Name=Lock Keys Indicator
 _Description=Lock Keys Indicator
 Authors=Ikey Doherty
-Copyright=Copyright © 2015 Ikey Doherty
+Copyright=Copyright © 2015-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=num-lock-symbolic

--- a/src/applets/lock-keys/LockKeysApplet.vala
+++ b/src/applets/lock-keys/LockKeysApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/notifications/NotificationsApplet.plugin.in
+++ b/src/applets/notifications/NotificationsApplet.plugin.in
@@ -3,6 +3,6 @@ Module=notificationsapplet.so
 Name=Notifications
 _Description=Notifications
 Authors=Ikey Doherty
-Copyright=Copyright © 2015 Ikey Doherty
+Copyright=Copyright © 2015-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=notifications-applet-symbolic

--- a/src/applets/notifications/NotificationsApplet.vala
+++ b/src/applets/notifications/NotificationsApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/ListItem.vala
+++ b/src/applets/places-indicator/ListItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/MessageRevealer.vala
+++ b/src/applets/places-indicator/MessageRevealer.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/MountItem.vala
+++ b/src/applets/places-indicator/MountItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlaceItem.vala
+++ b/src/applets/places-indicator/PlaceItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlacesIndicator.plugin.in
+++ b/src/applets/places-indicator/PlacesIndicator.plugin.in
@@ -3,6 +3,6 @@ Module=libplacesindicator.so
 Name=Places
 _Description=Places
 Authors=Solus Project
-Copyright=Copyright © 2016 Solus Project
+Copyright=Copyright © 2016-2017 Solus Project
 Website=https://solus-project.com
 Icon=drive-harddisk-symbolic

--- a/src/applets/places-indicator/PlacesIndicator.vala
+++ b/src/applets/places-indicator/PlacesIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlacesIndicatorWindow.vala
+++ b/src/applets/places-indicator/PlacesIndicatorWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlacesSection.vala
+++ b/src/applets/places-indicator/PlacesSection.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/VolumeItem.vala
+++ b/src/applets/places-indicator/VolumeItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/raven-trigger/RavenTriggerApplet.plugin.in
+++ b/src/applets/raven-trigger/RavenTriggerApplet.plugin.in
@@ -3,6 +3,6 @@ Module=raventriggerapplet.so
 Name=Raven Trigger
 _Description=Raven Sidebar Control
 Authors=Ikey Doherty
-Copyright=Copyright © 2016 Ikey Doherty
+Copyright=Copyright © 2016-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=pane-show-symbolic

--- a/src/applets/raven-trigger/RavenTriggerApplet.vala
+++ b/src/applets/raven-trigger/RavenTriggerApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/separator/SeparatorApplet.plugin.in
+++ b/src/applets/separator/SeparatorApplet.plugin.in
@@ -3,6 +3,6 @@ Module=separatorapplet.so
 Name=Separator
 _Description=Separator
 Authors=Ikey Doherty
-Copyright=Copyright © 2015 Ikey Doherty
+Copyright=Copyright © 2015-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=separator-symbolic

--- a/src/applets/separator/SeparatorApplet.vala
+++ b/src/applets/separator/SeparatorApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/show-desktop/ShowDesktopApplet.plugin.in
+++ b/src/applets/show-desktop/ShowDesktopApplet.plugin.in
@@ -3,6 +3,6 @@ Module=showdesktopapplet.so
 Name=Show Desktop Button
 _Description=Show Desktop Button
 Authors=Ikey Doherty
-Copyright=Copyright © 2015 Ikey Doherty
+Copyright=Copyright © 2015-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=user-desktop-symbolic

--- a/src/applets/show-desktop/ShowDesktopApplet.vala
+++ b/src/applets/show-desktop/ShowDesktopApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/spacer/SpacerApplet.plugin.in
+++ b/src/applets/spacer/SpacerApplet.plugin.in
@@ -3,6 +3,6 @@ Module=spacerapplet.so
 Name=Spacer
 _Description=Spacer
 Authors=Ikey Doherty
-Copyright=Copyright © 2015 Ikey Doherty
+Copyright=Copyright © 2015-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=spacer-symbolic

--- a/src/applets/spacer/SpacerApplet.vala
+++ b/src/applets/spacer/SpacerApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/status/BluetoothIndicator.vala
+++ b/src/applets/status/BluetoothIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * Copyright (C) 2015 Alberts Muktupāvels
  *
  * This program is free software; you can redistribute it and/or modify

--- a/src/applets/status/PowerIndicator.vala
+++ b/src/applets/status/PowerIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/status/SoundIndicator.vala
+++ b/src/applets/status/SoundIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/status/StatusApplet.plugin.in
+++ b/src/applets/status/StatusApplet.plugin.in
@@ -3,6 +3,6 @@ Module=statusapplet.so
 Name=Status Indicator
 _Description=Status Indicator
 Authors=Ikey Doherty
-Copyright=Copyright © 2015 Ikey Doherty
+Copyright=Copyright © 2015-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=avatar-default-symbolic

--- a/src/applets/status/StatusApplet.vala
+++ b/src/applets/status/StatusApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/status/meson.build
+++ b/src/applets/status/meson.build
@@ -38,6 +38,9 @@ shared_library(
     'statusapplet',
     applet_status_sources,
     dependencies: applet_status_deps,
+    c_args: [
+        '-lm'
+    ],
     vala_args: [
         '--pkg', 'budgie-1.0',
         '--pkg', 'libpeas-1.0',

--- a/src/applets/tasklist/TasklistApplet.plugin.in
+++ b/src/applets/tasklist/TasklistApplet.plugin.in
@@ -3,6 +3,6 @@ Module=tasklistapplet.so
 Name=Task List
 _Description=Task List
 Authors=Ikey Doherty
-Copyright=Copyright © 2015 Ikey Doherty
+Copyright=Copyright © 2015-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=task-list-symbolic

--- a/src/applets/tasklist/TasklistApplet.vala
+++ b/src/applets/tasklist/TasklistApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/tray/TrayApplet.plugin.in
+++ b/src/applets/tray/TrayApplet.plugin.in
@@ -3,6 +3,6 @@ Module=trayapplet.so
 Name=System Tray
 _Description=System Tray
 Authors=Ikey Doherty
-Copyright=Copyright © 2015 Ikey Doherty
+Copyright=Copyright © 2015-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=system-tray-symbolic

--- a/src/applets/tray/TrayApplet.vala
+++ b/src/applets/tray/TrayApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/tray/TrayApplet.vala
+++ b/src/applets/tray/TrayApplet.vala
@@ -49,7 +49,6 @@ public class TrayApplet : Budgie.Applet
                 tray.set_icon_size(icon_size);
                 queue_resize();
                 tray.queue_resize();
-                tray.force_redraw();
             }
         });
 
@@ -86,7 +85,7 @@ public class TrayApplet : Budgie.Applet
             return;
         }
 
-        tray = new Na.Tray.for_screen(get_screen(), Gtk.Orientation.HORIZONTAL);
+        tray = new Na.Tray.for_screen(Gtk.Orientation.HORIZONTAL);
         if (tray == null) {
             var label = new Gtk.Label("Tray unavailable");
             add(label);
@@ -95,15 +94,15 @@ public class TrayApplet : Budgie.Applet
         }
         tray.set_icon_size(icon_size);
 
-        Gdk.Color fg;
-        Gdk.Color warning;
-        Gdk.Color error;
-        Gdk.Color success;
+        Gdk.RGBA fg = {};
+        Gdk.RGBA warning = {};
+        Gdk.RGBA error = {};
+        Gdk.RGBA success = {};
 
-        Gdk.Color.parse("white", out fg);
-        Gdk.Color.parse("red", out error);
-        Gdk.Color.parse("orange", out warning);
-        Gdk.Color.parse("white", out success);
+        fg.parse("white");
+        warning.parse("red");
+        error.parse("orange");
+        success.parse("white");
 
         tray.set_colors(fg, error, warning, success);
         box.add(tray);
@@ -114,7 +113,6 @@ public class TrayApplet : Budgie.Applet
             return;
         }
         win.queue_draw();
-        tray.force_redraw();
         this.queue_resize();
     }
 }

--- a/src/applets/user-indicator/DBusInterfaces.vala
+++ b/src/applets/user-indicator/DBusInterfaces.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/user-indicator/UserIndicator.plugin.in
+++ b/src/applets/user-indicator/UserIndicator.plugin.in
@@ -3,6 +3,6 @@ Module=libuserindicator.so
 Name=User Indicator
 _Description=User Indicator
 Authors=Solus Project
-Copyright=Copyright © 2016 Solus Project
+Copyright=Copyright © 2016-2017 Solus Project
 Website=https://solus-project.com
 Icon=system-users-symbolic

--- a/src/applets/user-indicator/UserIndicator.vala
+++ b/src/applets/user-indicator/UserIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/user-indicator/UserIndicatorWindow.vala
+++ b/src/applets/user-indicator/UserIndicatorWindow.vala
@@ -100,7 +100,7 @@ public class UserIndicatorWindow : Gtk.Popover {
 
         IndicatorItem lock_menu = new IndicatorItem(_("Lock"), "system-lock-screen-symbolic", false);
         IndicatorItem suspend_menu = new IndicatorItem(_("Suspend"), "media-playback-pause-symbolic", false);
-        IndicatorItem hibernate_menu = new IndicatorItem(_("Hibernate"), "media-playback-pause-symbolic", false);
+        IndicatorItem hibernate_menu = new IndicatorItem(_("Hibernate"), "document-save-symbolic", false);
         IndicatorItem reboot_menu = new IndicatorItem(_("Restart"), "media-playlist-repeat-symbolic", false);
         IndicatorItem shutdown_menu = new IndicatorItem(_("Shutdown"), "system-shutdown-symbolic", false);
 

--- a/src/applets/user-indicator/UserIndicatorWindow.vala
+++ b/src/applets/user-indicator/UserIndicatorWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Solus Project
+ * Copyright © 2015-2017 Solus Project
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/workspaces/WorkspacesApplet.plugin.in
+++ b/src/applets/workspaces/WorkspacesApplet.plugin.in
@@ -3,6 +3,6 @@ Module=workspacesapplet.so
 Name=Workspace Switcher
 _Description=Workspace Switcher
 Authors=Ikey Doherty
-Copyright=Copyright © 2015 Ikey Doherty
+Copyright=Copyright © 2015-2017 Ikey Doherty
 Website=https://solus-project.com
 Icon=workspace-switcher-symbolic

--- a/src/applets/workspaces/WorkspacesApplet.vala
+++ b/src/applets/workspaces/WorkspacesApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/config/budgie-config.c
+++ b/src/config/budgie-config.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/config/budgie-config.h
+++ b/src/config/budgie-config.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015 Ikey Doherty
+ * Copyright © 2015-2017 Ikey Doherty
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/config/budgie-config.vapi
+++ b/src/config/budgie-config.vapi
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/daemon/endsession.vala
+++ b/src/daemon/endsession.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/main.vala
+++ b/src/daemon/main.vala
@@ -48,6 +48,7 @@ public static int main(string[] args)
     OptionContext ctx;
     Budgie.ServiceManager? manager = null;
     Budgie.EndSessionDialog? end_dialog = null;
+    Budgie.SettingsManager? settings = null;
     Wnck.Screen? screen = null;
 
     Intl.setlocale(LocaleCategory.ALL, "");
@@ -78,6 +79,7 @@ public static int main(string[] args)
 
     manager = new Budgie.ServiceManager(replace);
     end_dialog = new Budgie.EndSessionDialog(replace);
+    settings = new Budgie.SettingsManager();
 
     /* Enter main loop */
     Gtk.main();

--- a/src/daemon/manager.vala
+++ b/src/daemon/manager.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2016-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/menus.vala
+++ b/src/daemon/menus.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2016-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/meson.build
+++ b/src/daemon/meson.build
@@ -21,6 +21,7 @@ daemon_sources = [
     'manager.vala',
     'menus.vala',
     'osd.vala',
+    'settings.vala',
     'tabswitcher.vala',
     daemon_resources,
 ]

--- a/src/daemon/osd.vala
+++ b/src/daemon/osd.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2016-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -1,0 +1,100 @@
+/*
+ * This file is part of budgie-desktop
+ * 
+ * Copyright (C) 2017 Ikey Doherty <ikey@solus-project.com>
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+namespace Budgie
+{
+
+/**
+ * The button layout style as set in budgie
+ */
+public enum ButtonPosition {
+    LEFT = 1 << 0,
+    TRADITIONAL = 1 << 1,
+}
+/**
+ * The SettingsManager currently only has a very simple job, and looks for
+ * session wide settings changes to respond to
+ */
+public class SettingsManager
+{
+    private GLib.Settings? wm_settings = null;
+    private GLib.Settings? xoverrides = null;
+
+    /**
+     * Create a new xsettings override based on the *Existing* key so that
+     * we don't dump any settings like Gdk/ScaleFactor, etc.
+     */
+    private Variant? new_filtered_xsetting(string button_layout)
+    {
+        /* These are the two new keys we want */
+        var builder = new VariantBuilder(new VariantType("a{sv}"));
+        builder.add("{sv}", "Gtk/ShellShowsAppMenu", new Variant.int32(0));
+        builder.add("{sv}", "Gtk/DecorationLayout", new Variant.string(button_layout));
+
+        Variant existing_vars = this.xoverrides.get_value("overrides");
+        VariantIter it = existing_vars.iterator();
+        string? k = null;
+        Variant? v = null;
+        while (it.next("{sv}", &k, &v)) {
+            if (k == "Gtk/ShellShowsAppMenu" || k == "Gtk/DecorationLayout") {
+                continue;
+            }
+            builder.add("{sv}", k, v);
+        }
+        return builder.end();
+    }
+
+    public SettingsManager()
+    {
+        /* Settings we need to write to */
+        xoverrides = new GLib.Settings("org.gnome.settings-daemon.plugins.xsettings");
+
+        wm_settings = new GLib.Settings("com.solus-project.budgie-wm");
+        wm_settings.changed.connect(this.on_wm_settings_changed);
+        this.on_wm_settings_changed("button-style");
+    }
+
+    private void on_wm_settings_changed(string key)
+    {
+        if (key != "button-style") {
+            return;
+        }
+
+        ButtonPosition style = (ButtonPosition)wm_settings.get_enum(key);
+        this.set_button_style(style);
+    }
+
+    /**
+     * Set the button layout to one of left or traditional
+     */
+    void set_button_style(ButtonPosition style)
+    {
+        Variant? xset = null;
+        string? wm_set = null;
+
+        switch (style) {
+        case ButtonPosition.LEFT:
+            xset = this.new_filtered_xsetting("close,minimize,maximize,menu:");
+            wm_set = "close,maximize,minimize,appmenu";
+            break;
+        case ButtonPosition.TRADITIONAL:
+        default:
+            xset = this.new_filtered_xsetting("menu:minimize,maximize,close");
+            wm_set = "appmenu:minimize,maximize,close";
+            break;
+        }
+        this.xoverrides.set_value("overrides", xset);
+        this.wm_settings.set_string("button-layout", wm_set);
+    }
+
+} /* End class SettingsManager (BudgieSettingsManager) */
+
+} /* End namespace Budgie */

--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -82,8 +82,8 @@ public class SettingsManager
 
         switch (style) {
         case ButtonPosition.LEFT:
-            xset = this.new_filtered_xsetting("close,minimize,maximize,menu:");
-            wm_set = "close,maximize,minimize,appmenu";
+            xset = this.new_filtered_xsetting("close,minimize,maximize:menu");
+            wm_set = "close,maximize,minimize:appmenu";
             break;
         case ButtonPosition.TRADITIONAL:
         default:

--- a/src/daemon/tabswitcher.ui
+++ b/src/daemon/tabswitcher.ui
@@ -57,7 +57,7 @@
             <property name="max_width_chars">45</property>
             <property name="xalign">0</property>
             <attributes>
-              <attribute name="weight" value="bold"/>
+              <attribute name="weight" value="semibold"/>
             </attributes>
             <style>
               <class name="budgie-switcher-title"/>

--- a/src/daemon/tabswitcher.ui
+++ b/src/daemon/tabswitcher.ui
@@ -14,14 +14,26 @@
         <property name="border_width">5</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkFlowBox" id="window_box">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="valign">start</property>
-            <property name="homogeneous">True</property>
-            <property name="column_spacing">6</property>
-            <property name="row_spacing">6</property>
-            <property name="max_children_per_line">8</property>
+            <property name="hexpand">True</property>
+            <child>
+              <object class="GtkFlowBox" id="window_box">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">start</property>
+                <property name="hexpand">True</property>
+                <property name="column_spacing">6</property>
+                <property name="row_spacing">6</property>
+                <property name="max_children_per_line">8</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -41,13 +53,20 @@
             <property name="hexpand">True</property>
             <property name="label" translatable="yes"> - </property>
             <property name="wrap">True</property>
+            <property name="width_chars">45</property>
+            <property name="max_width_chars">45</property>
+            <property name="xalign">0</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
             <style>
               <class name="budgie-switcher-title"/>
             </style>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="pack_type">end</property>
             <property name="position">1</property>
           </packing>
         </child>

--- a/src/daemon/tabswitcher.ui
+++ b/src/daemon/tabswitcher.ui
@@ -21,6 +21,7 @@
             <property name="homogeneous">True</property>
             <property name="column_spacing">6</property>
             <property name="row_spacing">6</property>
+            <property name="max_children_per_line">8</property>
           </object>
           <packing>
             <property name="expand">True</property>

--- a/src/daemon/tabswitcher.ui
+++ b/src/daemon/tabswitcher.ui
@@ -52,8 +52,9 @@
             <property name="margin_bottom">6</property>
             <property name="hexpand">True</property>
             <property name="label" translatable="yes"> - </property>
-            <property name="wrap">True</property>
+            <property name="ellipsize">end</property>
             <property name="width_chars">45</property>
+            <property name="single_line_mode">True</property>
             <property name="max_width_chars">45</property>
             <property name="xalign">0</property>
             <attributes>

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -61,7 +61,7 @@ public class TabSwitcherWidget : Gtk.Image {
     {
         Object();
         string? title = window.get_name();
-        this.title = window.has_name() ? title : " - ";
+        this.title = window.has_name() ? title : "";
         this.title = this.title.strip();
         this.wnck_window = window;
         this.xid = (uint32)window.get_xid();

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -311,10 +311,11 @@ public class TabSwitcher : Object
         mod_timeout = 0;
         Gdk.ModifierType modifier;
         Gdk.Display.get_default().get_device_manager().get_client_pointer().get_state(Gdk.get_default_root_window(), null, out modifier);
-        if ((modifier & Gdk.ModifierType.MOD1_MASK) == 0) {
+        if ((modifier & Gdk.ModifierType.MOD1_MASK) == 0 && (modifier & Gdk.ModifierType.MOD4_MASK) == 0) {
             switcher_window.hide();
             return false;
         }
+
         /* restart the timeout */
         return true;
     }

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -137,6 +137,7 @@ public class TabSwitcherWindow : Gtk.Window
     public TabSwitcherWindow()
     {
         Object(type: Gtk.WindowType.POPUP, type_hint: Gdk.WindowTypeHint.NOTIFICATION);
+        set_position(Gtk.WindowPosition.CENTER_ALWAYS);
         this.xids = new HashTable<uint32, TabSwitcherWidget?>(GLib.direct_hash, GLib.direct_equal);
 
         this.hide.connect(this.on_hide);
@@ -192,7 +193,7 @@ public class TabSwitcherWindow : Gtk.Window
 
         /* For now just center it */
         int x = bounds.x + ((bounds.width / 2) - (alloc.width / 2));
-        int y = bounds.y + ((int)(bounds.height * 0.5));
+        int y = bounds.y + ((bounds.height / 2) - (alloc.height / 2));
         move(x, y);
     }
 

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -35,7 +35,7 @@ public const string SWITCHER_DBUS_OBJECT_PATH = "/org/budgie_desktop/TabSwitcher
 /**
  * A TabSwitcherWidget is used for each icon in the display
  */
-public class TabSwitcherWidget : Gtk.Box {
+public class TabSwitcherWidget : Gtk.Image {
 
     /**
      * Display title for the window
@@ -54,14 +54,12 @@ public class TabSwitcherWidget : Gtk.Box {
 
     public unowned Wnck.Window? wnck_window = null;
 
-    private Gtk.Image? image = null;
-
     /**
      * Construct a new TabSwitcherWidget with the given xid + title
      */
     public TabSwitcherWidget(Wnck.Window? window, uint32 usertime)
     {
-        Object(orientation: Gtk.Orientation.HORIZONTAL);
+        Object();
         string? title = window.get_name();
         this.title = window.has_name() ? title : " - ";
         this.title = this.title.strip();
@@ -72,12 +70,10 @@ public class TabSwitcherWidget : Gtk.Box {
         set_property("margin", 10);
 
         /* TODO: Get the proper THEME icon for this ! */
-        image = new Gtk.Image();
-        image.set_from_pixbuf(wnck_window.get_icon());
-        image.set_pixel_size(48);
-        image.halign = Gtk.Align.CENTER;
-        image.valign = Gtk.Align.CENTER;
-        pack_start(image, false, false, 0);
+        set_from_pixbuf(wnck_window.get_icon());
+        set_pixel_size(48);
+        halign = Gtk.Align.CENTER;
+        valign = Gtk.Align.CENTER;
     }
 }
 

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -226,7 +226,7 @@ public class TabSwitcherWindow : Gtk.Window
         if (widget == null) {
             return;
         }
-        window_title.set_markup("<b>%s</b>".printf(Markup.escape_text(widget.title)));
+        window_title.set_text(widget.title);
         window_box.select_child(widget.get_parent() as Gtk.FlowBoxChild);
     }
 } /* End class Switcher (BudgieSwitcher) */

--- a/src/imports/natray/fixedtip.c
+++ b/src/imports/natray/fixedtip.c
@@ -130,13 +130,23 @@ static void
 get_monitor_geometry (GdkWindow    *window,
                       GdkRectangle *geometry)
 {
-  GdkDisplay *display;
+  GdkDisplay *display = NULL;
+#if GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 22
+  GdkScreen *screen = NULL;
+  gint monitor;
+
+  screen = gdk_screen_get_default ();
+  monitor = gdk_screen_get_monitor_at_window (screen, window);
+
+  gdk_screen_get_monitor_geometry (screen, monitor, geometry);
+#else
   GdkMonitor *monitor;
 
   display = gdk_display_get_default ();
   monitor = gdk_display_get_monitor_at_window (display, window);
 
   gdk_monitor_get_geometry (monitor, geometry);
+#endif
 }
 
 static void

--- a/src/imports/natray/fixedtip.c
+++ b/src/imports/natray/fixedtip.c
@@ -1,9 +1,9 @@
 /* Metacity fixed tooltip routine */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2003-2006 Vincent Untz
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -13,7 +13,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
@@ -114,8 +114,6 @@ na_fixed_tip_init (NaFixedTip *fixedtip)
 
   label = gtk_label_new (NULL);
   gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
-  gtk_widget_set_halign (label, GTK_ALIGN_CENTER);
-  gtk_widget_set_valign (label, GTK_ALIGN_CENTER);
   gtk_widget_show (label);
   gtk_container_add (GTK_CONTAINER (fixedtip), label);
   fixedtip->priv->label = label;
@@ -129,22 +127,31 @@ na_fixed_tip_init (NaFixedTip *fixedtip)
 }
 
 static void
+get_monitor_geometry (GdkWindow    *window,
+                      GdkRectangle *geometry)
+{
+  GdkDisplay *display;
+  GdkMonitor *monitor;
+
+  display = gdk_display_get_default ();
+  monitor = gdk_display_get_monitor_at_window (display, window);
+
+  gdk_monitor_get_geometry (monitor, geometry);
+}
+
+static void
 na_fixed_tip_position (NaFixedTip *fixedtip)
 {
-  GdkScreen      *screen;
   GdkWindow      *parent_window;
+  GdkRectangle    monitor;
   GtkRequisition  req;
   int             root_x;
   int             root_y;
   int             parent_width;
   int             parent_height;
-  int             screen_width;
-  int             screen_height;
 
-  screen = gtk_widget_get_screen (fixedtip->priv->parent);
   parent_window = gtk_widget_get_window (fixedtip->priv->parent);
-
-  gtk_window_set_screen (GTK_WINDOW (fixedtip), screen);
+  get_monitor_geometry (parent_window, &monitor);
 
   gtk_widget_get_preferred_size (GTK_WIDGET (fixedtip), &req, NULL);
 
@@ -152,34 +159,31 @@ na_fixed_tip_position (NaFixedTip *fixedtip)
   parent_width = gdk_window_get_width (parent_window);
   parent_height = gdk_window_get_height (parent_window);
 
-  screen_width = gdk_screen_get_width (screen);
-  screen_height = gdk_screen_get_height (screen);
-
   /* pad between panel and message window */
 #define PAD 5
-  
+
   if (fixedtip->priv->orientation == GTK_ORIENTATION_VERTICAL)
     {
-      if (root_x <= screen_width / 2)
+      if (root_x <= monitor.width / 2)
         root_x += parent_width + PAD;
       else
         root_x -= req.width + PAD;
     }
   else
     {
-      if (root_y <= screen_height / 2)
+      if (root_y <= monitor.height / 2)
         root_y += parent_height + PAD;
       else
         root_y -= req.height + PAD;
     }
 
   /* Push onscreen */
-  if ((root_x + req.width) > screen_width)
-    root_x = screen_width - req.width;
+  if ((root_x + req.width) > monitor.width)
+    root_x = monitor.width - req.width;
 
-  if ((root_y + req.height) > screen_height)
-    root_y = screen_height - req.height;
-  
+  if ((root_y + req.height) > monitor.height)
+    root_y = monitor.height - req.height;
+
   gtk_window_move (GTK_WINDOW (fixedtip), root_x, root_y);
 }
 
@@ -217,7 +221,7 @@ na_fixed_tip_new (GtkWidget      *parent,
   //FIXME: would be nice to be able to get the toplevel for the tip, but this
   //doesn't work
   GtkWidget  *toplevel;
-  
+
   toplevel = gtk_widget_get_toplevel (parent);
   /*
   if (toplevel && gtk_widget_is_toplevel (toplevel) && GTK_IS_WINDOW (toplevel))

--- a/src/imports/natray/fixedtip.h
+++ b/src/imports/natray/fixedtip.h
@@ -1,9 +1,9 @@
 /* Fixed tooltip routine */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington, 2002 Red Hat Inc.
  * Copyright (C) 2003-2006 Vincent Untz
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -13,7 +13,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */

--- a/src/imports/natray/meson.build
+++ b/src/imports/natray/meson.build
@@ -17,6 +17,10 @@ libnatray = static_library(
     'natray',
     libnatray_sources,
     dependencies: libnatray_deps,
+    include_directories: [
+        include_directories('.'),
+        include_directories(join_paths('..', '..', '..')),
+    ],
 )
 
 link_libnatray = declare_dependency(

--- a/src/imports/natray/na-tray-child.c
+++ b/src/imports/natray/na-tray-child.c
@@ -17,6 +17,7 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <string.h>
 
 #include "na-tray-child.h"
@@ -124,7 +125,7 @@ na_tray_child_get_preferred_height (GtkWidget *widget,
 
   if (*natural_height < 16)
     *natural_height = 16;
- }
+}
 
 static void
 na_tray_child_size_allocate (GtkWidget      *widget,
@@ -287,8 +288,7 @@ na_tray_child_new (GdkScreen *screen,
   depth = gdk_visual_get_depth (visual);
 
   visual_has_alpha = red_prec + blue_prec + green_prec < depth;
-  child->has_alpha = (visual_has_alpha &&
-                      gdk_display_supports_composite (gdk_screen_get_display (screen)));
+  child->has_alpha = (visual_has_alpha && gdk_screen_is_composited (screen));
 
   child->composited = child->has_alpha;
 
@@ -323,7 +323,7 @@ na_tray_child_get_title (NaTrayChild *child)
                                False, utf8_string,
                                &type, &format, &nitems,
                                &bytes_after, (guchar **)&val);
-  
+
   if (gdk_error_trap_pop () || result != Success)
     return NULL;
 

--- a/src/imports/natray/na-tray-manager.h
+++ b/src/imports/natray/na-tray-manager.h
@@ -37,7 +37,7 @@ G_BEGIN_DECLS
 #define NA_IS_TRAY_MANAGER(obj)			(G_TYPE_CHECK_INSTANCE_TYPE ((obj), NA_TYPE_TRAY_MANAGER))
 #define NA_IS_TRAY_MANAGER_CLASS(klass)		(G_TYPE_CHECK_CLASS_TYPE ((klass), NA_TYPE_TRAY_MANAGER))
 #define NA_TRAY_MANAGER_GET_CLASS(obj)		(G_TYPE_INSTANCE_GET_CLASS ((obj), NA_TYPE_TRAY_MANAGER, NaTrayManagerClass))
-	
+
 typedef struct _NaTrayManager	    NaTrayManager;
 typedef struct _NaTrayManagerClass  NaTrayManagerClass;
 
@@ -50,16 +50,16 @@ struct _NaTrayManager
   Atom    opcode_atom;
   Atom    message_data_atom;
 #endif
-  
+
   GtkWidget *invisible;
   GdkScreen *screen;
   GtkOrientation orientation;
   gint padding;
   gint icon_size;
-  GdkColor fg;
-  GdkColor error;
-  GdkColor warning;
-  GdkColor success;
+  GdkRGBA fg;
+  GdkRGBA error;
+  GdkRGBA warning;
+  GdkRGBA success;
 
   GList *messages;
   GHashTable *socket_table;
@@ -79,7 +79,7 @@ struct _NaTrayManagerClass
 			      const gchar        *message,
 			      glong               id,
 			      glong               timeout);
-  
+
   void (* message_cancelled) (NaTrayManager      *manager,
 			      NaTrayChild        *child,
 			      glong               id);
@@ -101,10 +101,10 @@ void            na_tray_manager_set_padding     (NaTrayManager      *manager,
 void            na_tray_manager_set_icon_size   (NaTrayManager      *manager,
 						 gint                padding);
 void            na_tray_manager_set_colors      (NaTrayManager      *manager,
-						 GdkColor           *fg,
-						 GdkColor           *error,
-						 GdkColor           *warning,
-						 GdkColor           *success);
+						 GdkRGBA            *fg,
+						 GdkRGBA            *error,
+						 GdkRGBA            *warning,
+						 GdkRGBA            *success);
 
 
 G_END_DECLS

--- a/src/imports/natray/na-tray.c
+++ b/src/imports/natray/na-tray.c
@@ -26,7 +26,7 @@
 #include "na-tray-manager.h"
 #include "fixedtip.h"
 
-#define ICON_SPACING 1
+#define ICON_SPACING 3
 #define MIN_BOX_SIZE 3
 
 struct _NaTray

--- a/src/imports/natray/na-tray.c
+++ b/src/imports/natray/na-tray.c
@@ -12,42 +12,34 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <string.h>
-
+#include "config.h"
 
 #include <gtk/gtk.h>
+#include <string.h>
 
+#include "na-tray.h"
 #include "na-tray-manager.h"
 #include "fixedtip.h"
 
-#include "na-tray.h"
+#define ICON_SPACING 1
+#define MIN_BOX_SIZE 3
 
-#define ICON_SPACING 5
-#define MIN_BOX_SIZE 22
-
-typedef struct
+struct _NaTray
 {
-  NaTrayManager *tray_manager;
-  GSList        *all_trays;
-  GHashTable    *icon_table;
-  GHashTable    *tip_table;
-} TraysScreen;
+  GtkBin          parent;
 
-struct _NaTrayPrivate
-{
-  GdkScreen   *screen;
-  TraysScreen *trays_screen;
+  NaTrayManager  *tray_manager;
+  GHashTable     *icon_table;
+  GHashTable     *tip_table;
 
-  GtkWidget *box;
+  GtkWidget      *box;
 
-  guint idle_redraw_id;
-
-  GtkOrientation orientation;
+  GtkOrientation  orientation;
 };
 
 typedef struct
@@ -59,7 +51,7 @@ typedef struct
 
 typedef struct
 {
-  NaTray *tray;      /* tray containing the tray icon */
+  NaTray     *tray;      /* tray containing the tray icon */
   GtkWidget  *icon;      /* tray icon sending the message */
   GtkWidget  *fixedtip;
   guint       source_id;
@@ -71,26 +63,11 @@ enum
 {
   PROP_0,
   PROP_ORIENTATION,
-  PROP_SCREEN
 };
-
-static gboolean     initialized   = FALSE;
-static TraysScreen *trays_screens = NULL;
 
 static void icon_tip_show_next (IconTip *icontip);
 
-/* NaTray */
-
 G_DEFINE_TYPE (NaTray, na_tray, GTK_TYPE_BIN)
-
-static NaTray *
-get_tray (TraysScreen *trays_screen)
-{
-  if (trays_screen->all_trays == NULL)
-    return NULL;
-  
-  return trays_screen->all_trays->data;
-}
 
 const char *ordered_roles[] = {
   "keyboard",
@@ -142,7 +119,6 @@ static int
 find_icon_position (NaTray    *tray,
                     GtkWidget *icon)
 {
-  NaTrayPrivate *priv;
   int            position;
   char          *class_a;
   const char    *role;
@@ -153,7 +129,6 @@ find_icon_position (NaTray    *tray,
    * defined by ordered_roles), and all other icons at the beginning of the box
    * (left in LTR). */
 
-  priv = tray->priv;
   position = 0;
 
   class_a = NULL;
@@ -169,7 +144,7 @@ find_icon_position (NaTray    *tray,
   role_position = find_role_position (role);
   g_object_set_data (G_OBJECT (icon), "role-position", GINT_TO_POINTER (role_position));
 
-  children = gtk_container_get_children (GTK_CONTAINER (priv->box));
+  children = gtk_container_get_children (GTK_CONTAINER (tray->box));
   for (l = g_list_last (children); l; l = l->prev)
     {
       GtkWidget *child = l->data;
@@ -191,70 +166,39 @@ find_icon_position (NaTray    *tray,
   return position;
 }
 
-static void refresh_toplevel (NaTray *tray)
-{
-  GtkWidget *win = NULL;
-
-  win = gtk_widget_get_toplevel (GTK_WIDGET (tray));
-
-  if (!win) {
-    return;
-  }
-
-  gtk_widget_queue_draw (win);
-}
-
 static void
 tray_added (NaTrayManager *manager,
             GtkWidget     *icon,
-            TraysScreen   *trays_screen)
+            NaTray        *tray)
 {
-  NaTray *tray;
-  NaTrayPrivate *priv;
   int position;
 
-  tray = get_tray (trays_screen);
-  if (tray == NULL)
-    return;
-
-  priv = tray->priv;
-
-  g_assert (priv->trays_screen == trays_screen);
-
-  g_hash_table_insert (trays_screen->icon_table, icon, tray);
+  g_hash_table_insert (tray->icon_table, icon, tray);
 
   position = find_icon_position (tray, icon);
-  gtk_box_pack_start (GTK_BOX (priv->box), icon, FALSE, FALSE, 0);
-  gtk_box_reorder_child (GTK_BOX (priv->box), icon, position);
+  gtk_box_pack_start (GTK_BOX (tray->box), icon, FALSE, FALSE, 0);
+  gtk_box_reorder_child (GTK_BOX (tray->box), icon, position);
 
   gtk_widget_show (icon);
-
-  refresh_toplevel (tray);
 }
 
 static void
 tray_removed (NaTrayManager *manager,
               GtkWidget     *icon,
-              TraysScreen   *trays_screen)
+              NaTray        *tray)
 {
-  NaTray *tray;
-  NaTrayPrivate *priv;
+  NaTray *icon_tray;
 
-  tray = g_hash_table_lookup (trays_screen->icon_table, icon);
-  if (tray == NULL)
+  icon_tray = g_hash_table_lookup (tray->icon_table, icon);
+  if (icon_tray == NULL)
     return;
 
-  priv = tray->priv;
+  g_assert (icon_tray == tray);
 
-  g_assert (tray->priv->trays_screen == trays_screen);
+  gtk_container_remove (GTK_CONTAINER (tray->box), icon);
 
-  gtk_container_remove (GTK_CONTAINER (priv->box), icon);
-
-  g_hash_table_remove (trays_screen->icon_table, icon);
-  /* this will also destroy the tip associated to this icon */
-  g_hash_table_remove (trays_screen->tip_table, icon);
-
-  refresh_toplevel (tray);
+  g_hash_table_remove (tray->icon_table, icon);
+  g_hash_table_remove (tray->tip_table, icon);
 }
 
 static void
@@ -337,7 +281,7 @@ icon_tip_show_next (IconTip *icontip)
   if (icontip->buffer == NULL)
     {
       /* this will also destroy the tip window */
-      g_hash_table_remove (icontip->tray->priv->trays_screen->tip_table,
+      g_hash_table_remove (icontip->tray->tip_table,
                            icontip->icon);
       return;
     }
@@ -379,17 +323,17 @@ message_sent (NaTrayManager *manager,
               const char    *text,
               glong          id,
               glong          timeout,
-              TraysScreen   *trays_screen)
+              NaTray        *tray)
 {
   IconTip       *icontip;
   IconTipBuffer  find_buffer;
   IconTipBuffer *buffer;
   gboolean       show_now;
 
-  icontip = g_hash_table_lookup (trays_screen->tip_table, icon);
+  icontip = g_hash_table_lookup (tray->tip_table, icon);
 
   find_buffer.id = id;
-  if (icontip && 
+  if (icontip &&
       (icontip->id == id ||
        g_slist_find_custom (icontip->buffer, &find_buffer,
                             icon_tip_buffer_compare) != NULL))
@@ -402,10 +346,10 @@ message_sent (NaTrayManager *manager,
 
   if (icontip == NULL)
     {
-      NaTray *tray;
+      NaTray *icon_tray;
 
-      tray = g_hash_table_lookup (trays_screen->icon_table, icon);
-      if (tray == NULL)
+      icon_tray = g_hash_table_lookup (tray->icon_table, icon);
+      if (icon_tray == NULL)
         {
           /* We don't know about the icon sending the message, so ignore it.
            * But this should never happen since NaTrayManager shouldn't send
@@ -419,7 +363,7 @@ message_sent (NaTrayManager *manager,
       icontip->tray = tray;
       icontip->icon = icon;
 
-      g_hash_table_insert (trays_screen->tip_table, icon, icontip);
+      g_hash_table_insert (tray->tip_table, icon, icontip);
 
       show_now = TRUE;
     }
@@ -440,14 +384,14 @@ static void
 message_cancelled (NaTrayManager *manager,
                    GtkWidget     *icon,
                    glong          id,
-                   TraysScreen   *trays_screen)
+                   NaTray        *tray)
 {
   IconTip       *icontip;
   IconTipBuffer  find_buffer;
   GSList        *cancel_buffer_l;
   IconTipBuffer *cancel_buffer;
 
-  icontip = g_hash_table_lookup (trays_screen->tip_table, icon);
+  icontip = g_hash_table_lookup (tray->tip_table, icon);
   if (icontip == NULL)
     return;
 
@@ -487,36 +431,30 @@ update_orientation_for_messages (gpointer key,
     return;
 
   if (icontip->fixedtip)
-    na_fixed_tip_set_orientation (icontip->fixedtip, tray->priv->orientation);
+    na_fixed_tip_set_orientation (icontip->fixedtip, tray->orientation);
 }
 
 static void
 update_size_and_orientation (NaTray *tray)
 {
-  NaTrayPrivate *priv = tray->priv;
+  gtk_orientable_set_orientation (GTK_ORIENTABLE (tray->box), tray->orientation);
 
-  gtk_orientable_set_orientation (GTK_ORIENTABLE (priv->box), priv->orientation);
+  g_hash_table_foreach (tray->tip_table, update_orientation_for_messages, tray);
 
-  /* This only happens when setting the property during object construction */
-  if (!priv->trays_screen)
-    return;
-
-  g_hash_table_foreach (priv->trays_screen->tip_table,
-                        update_orientation_for_messages, tray);
-
-  if (get_tray (priv->trays_screen) == tray)
-    na_tray_manager_set_orientation (priv->trays_screen->tray_manager,
-                                     priv->orientation);
+  na_tray_manager_set_orientation (tray->tray_manager, tray->orientation);
 
   /* note, you want this larger if the frame has non-NONE relief by default. */
-  switch (priv->orientation)
+  switch (tray->orientation)
     {
     case GTK_ORIENTATION_VERTICAL:
       /* Give box a min size so the frame doesn't look dumb */
-      gtk_widget_set_size_request (priv->box, MIN_BOX_SIZE, -1);
+      gtk_widget_set_size_request (tray->box, MIN_BOX_SIZE, -1);
       break;
     case GTK_ORIENTATION_HORIZONTAL:
-      gtk_widget_set_size_request (priv->box, -1, MIN_BOX_SIZE);
+      gtk_widget_set_size_request (tray->box, -1, MIN_BOX_SIZE);
+      break;
+    default:
+      g_assert_not_reached ();
       break;
     }
 }
@@ -559,141 +497,58 @@ na_tray_draw_box (GtkWidget *box,
 static void
 na_tray_init (NaTray *tray)
 {
-  NaTrayPrivate *priv;
+  tray->orientation = GTK_ORIENTATION_HORIZONTAL;
 
-  priv = tray->priv = G_TYPE_INSTANCE_GET_PRIVATE (tray, NA_TYPE_TRAY, NaTrayPrivate);
-
-  priv->screen = NULL;
-  priv->orientation = GTK_ORIENTATION_HORIZONTAL;
-
-
-  priv->box = gtk_box_new (priv->orientation, ICON_SPACING);
-  g_signal_connect (priv->box, "draw",
-                    G_CALLBACK (na_tray_draw_box), NULL);
-  gtk_container_add (GTK_CONTAINER (tray), priv->box);
-  gtk_widget_show (priv->box);
+  tray->box = gtk_box_new (tray->orientation, ICON_SPACING);
+  g_signal_connect (tray->box, "draw", G_CALLBACK (na_tray_draw_box), NULL);
+  gtk_container_add (GTK_CONTAINER (tray), tray->box);
+  gtk_widget_show (tray->box);
 }
 
-static GObject *
-na_tray_constructor (GType type,
-                     guint n_construct_properties,
-                     GObjectConstructParam *construct_params)
+static void
+na_tray_constructed (GObject *object)
 {
-  GObject *object;
   NaTray *tray;
-  NaTrayPrivate *priv;
-  int screen_number;
+  GdkScreen *screen;
 
-  object = G_OBJECT_CLASS (na_tray_parent_class)->constructor (type,
-                                                               n_construct_properties,
-                                                               construct_params);
+  G_OBJECT_CLASS (na_tray_parent_class)->constructed (object);
+
   tray = NA_TRAY (object);
-  priv = tray->priv;
+  screen = gdk_screen_get_default ();
 
-  g_assert (priv->screen != NULL);
+  tray->tray_manager = na_tray_manager_new ();
 
-  if (!initialized)
+  if (na_tray_manager_manage_screen (tray->tray_manager, screen))
     {
-      GdkDisplay *display;
-      int n_screens;
+      g_signal_connect (tray->tray_manager, "tray-icon-added",
+                        G_CALLBACK (tray_added), tray);
+      g_signal_connect (tray->tray_manager, "tray-icon-removed",
+                        G_CALLBACK (tray_removed), tray);
+      g_signal_connect (tray->tray_manager, "message-sent",
+                        G_CALLBACK (message_sent), tray);
+      g_signal_connect (tray->tray_manager, "message-cancelled",
+                        G_CALLBACK (message_cancelled), tray);
 
-      display = gdk_display_get_default ();
-      n_screens = gdk_display_get_n_screens (display);
-      trays_screens = g_new0 (TraysScreen, n_screens);
-      initialized = TRUE;
+      tray->icon_table = g_hash_table_new (NULL, NULL);
+      tray->tip_table = g_hash_table_new_full (NULL, NULL, NULL, icon_tip_free);
     }
-
-  screen_number = gdk_screen_get_number (priv->screen);
-
-  if (trays_screens [screen_number].tray_manager == NULL)
+  else
     {
-      NaTrayManager *tray_manager;
-
-      tray_manager = na_tray_manager_new ();
-
-      if (na_tray_manager_manage_screen (tray_manager, priv->screen))
-        {
-          trays_screens [screen_number].tray_manager = tray_manager;
-
-          g_signal_connect (tray_manager, "tray_icon_added",
-                            G_CALLBACK (tray_added),
-                            &trays_screens [screen_number]);
-          g_signal_connect (tray_manager, "tray_icon_removed",
-                            G_CALLBACK (tray_removed),
-                            &trays_screens [screen_number]);
-          g_signal_connect (tray_manager, "message_sent",
-                            G_CALLBACK (message_sent),
-                            &trays_screens [screen_number]);
-          g_signal_connect (tray_manager, "message_cancelled",
-                            G_CALLBACK (message_cancelled),
-                            &trays_screens [screen_number]);
-
-          trays_screens [screen_number].icon_table = g_hash_table_new (NULL,
-                                                                       NULL);
-          trays_screens [screen_number].tip_table = g_hash_table_new_full (
-                                                                NULL,
-                                                                NULL,
-                                                                NULL,
-                                                                icon_tip_free);
-        }
-      else
-        {
-          g_printerr ("System tray didn't get the system tray manager selection for screen %d\n",
-		      screen_number);
-          g_object_unref (tray_manager);
-        }
+      g_printerr ("System tray didn't get the system tray manager selection\n");
+      g_clear_object (&tray->tray_manager);
     }
-      
-  priv->trays_screen = &trays_screens [screen_number];
-  trays_screens [screen_number].all_trays = g_slist_append (trays_screens [screen_number].all_trays,
-                                                            tray);
 
   update_size_and_orientation (tray);
-
-  return object;
 }
 
 static void
 na_tray_dispose (GObject *object)
 {
   NaTray *tray = NA_TRAY (object);
-  NaTrayPrivate *priv = tray->priv;
-  TraysScreen *trays_screen = priv->trays_screen;
 
-  if (trays_screen != NULL)
-    {
-      trays_screen->all_trays = g_slist_remove (trays_screen->all_trays, tray);
-
-      if (trays_screen->all_trays == NULL)
-        {
-          /* Make sure we drop the manager selection */
-          g_object_unref (trays_screen->tray_manager);
-          trays_screen->tray_manager = NULL;
-
-          g_hash_table_destroy (trays_screen->icon_table);
-          trays_screen->icon_table = NULL;
-
-          g_hash_table_destroy (trays_screen->tip_table);
-          trays_screen->tip_table = NULL;
-        }
-      else
-        {
-          NaTray *new_tray;
-
-          new_tray = get_tray (trays_screen);
-          if (new_tray != NULL)
-            na_tray_manager_set_orientation (trays_screen->tray_manager,
-                                             na_tray_get_orientation (new_tray));
-        }
-    }
-
-  priv->trays_screen = NULL;
-
-  if (priv->idle_redraw_id != 0)
-    {
-      g_source_remove (priv->idle_redraw_id);
-      priv->idle_redraw_id = 0;
-    }
+  g_clear_object (&tray->tray_manager);
+  g_clear_pointer (&tray->icon_table, g_hash_table_destroy);
+  g_clear_pointer (&tray->tip_table, g_hash_table_destroy);
 
   G_OBJECT_CLASS (na_tray_parent_class)->dispose (object);
 }
@@ -705,15 +560,11 @@ na_tray_set_property (GObject      *object,
 		      GParamSpec   *pspec)
 {
   NaTray *tray = NA_TRAY (object);
-  NaTrayPrivate *priv = tray->priv;
 
   switch (prop_id)
     {
     case PROP_ORIENTATION:
       na_tray_set_orientation (tray, g_value_get_enum (value));
-      break;
-    case PROP_SCREEN:
-      priv->screen = g_value_get_object (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -755,7 +606,7 @@ na_tray_class_init (NaTrayClass *klass)
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
-  gobject_class->constructor = na_tray_constructor;
+  gobject_class->constructed = na_tray_constructed;
   gobject_class->set_property = na_tray_set_property;
   gobject_class->dispose = na_tray_dispose;
   widget_class->get_preferred_width = na_tray_get_preferred_width;
@@ -773,27 +624,12 @@ na_tray_class_init (NaTrayClass *klass)
 			G_PARAM_STATIC_NAME |
 			G_PARAM_STATIC_NICK |
 			G_PARAM_STATIC_BLURB));
-  
-  g_object_class_install_property
-    (gobject_class,
-     PROP_SCREEN,
-     g_param_spec_object ("screen", "screen", "screen",
-			  GDK_TYPE_SCREEN,
-			  G_PARAM_WRITABLE |
-			  G_PARAM_CONSTRUCT_ONLY |
-			  G_PARAM_STATIC_NAME |
-			  G_PARAM_STATIC_NICK |
-			  G_PARAM_STATIC_BLURB));
-
-  g_type_class_add_private (gobject_class, sizeof (NaTrayPrivate));
 }
 
 NaTray *
-na_tray_new_for_screen (GdkScreen      *screen,
-		        GtkOrientation  orientation)
+na_tray_new_for_screen (GtkOrientation orientation)
 {
   return g_object_new (NA_TYPE_TRAY,
-		       "screen", screen,
 		       "orientation", orientation,
 		       NULL);
 }
@@ -802,12 +638,10 @@ void
 na_tray_set_orientation (NaTray         *tray,
 			 GtkOrientation  orientation)
 {
-  NaTrayPrivate *priv = tray->priv;
-
-  if (orientation == priv->orientation)
+  if (orientation == tray->orientation)
     return;
-  
-  priv->orientation = orientation;
+
+  tray->orientation = orientation;
 
   update_size_and_orientation (tray);
 }
@@ -815,61 +649,29 @@ na_tray_set_orientation (NaTray         *tray,
 GtkOrientation
 na_tray_get_orientation (NaTray *tray)
 {
-  return tray->priv->orientation;
-}
-
-static gboolean
-idle_redraw_cb (NaTray *tray)
-{
-  NaTrayPrivate *priv = tray->priv;
-
-  gtk_container_foreach (GTK_CONTAINER (priv->box), (GtkCallback)na_tray_child_force_redraw, tray);
-  
-  priv->idle_redraw_id = 0;
-
-  return FALSE;
+  return tray->orientation;
 }
 
 void
 na_tray_set_padding (NaTray *tray,
                      gint    padding)
 {
-  NaTrayPrivate *priv = tray->priv;
-
-  if (get_tray (priv->trays_screen) == tray)
-    na_tray_manager_set_padding (priv->trays_screen->tray_manager, padding);
+  na_tray_manager_set_padding (tray->tray_manager, padding);
 }
 
 void
 na_tray_set_icon_size (NaTray *tray,
                        gint    size)
 {
-  NaTrayPrivate *priv = tray->priv;
-
-  if (get_tray (priv->trays_screen) == tray)
-    na_tray_manager_set_icon_size (priv->trays_screen->tray_manager, size);
+  na_tray_manager_set_icon_size (tray->tray_manager, size);
 }
 
 void
 na_tray_set_colors (NaTray   *tray,
-                    GdkColor *fg,
-                    GdkColor *error,
-                    GdkColor *warning,
-                    GdkColor *success)
+                    GdkRGBA  *fg,
+                    GdkRGBA  *error,
+                    GdkRGBA  *warning,
+                    GdkRGBA  *success)
 {
-  NaTrayPrivate *priv = tray->priv;
-
-  if (get_tray (priv->trays_screen) == tray)
-    na_tray_manager_set_colors (priv->trays_screen->tray_manager, fg, error, warning, success);
-}
-
-void
-na_tray_force_redraw (NaTray *tray)
-{
-  NaTrayPrivate *priv = tray->priv;
-
-  /* Force the icons to redraw their backgrounds.
-   */
-  if (priv->idle_redraw_id == 0)
-    priv->idle_redraw_id = g_idle_add ((GSourceFunc) idle_redraw_cb, tray);
+  na_tray_manager_set_colors (tray->tray_manager, fg, error, warning, success);
 }

--- a/src/imports/natray/na-tray.h
+++ b/src/imports/natray/na-tray.h
@@ -22,39 +22,15 @@
 #ifndef __NA_TRAY_H__
 #define __NA_TRAY_H__
 
-#ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
-#endif
 #include <gtk/gtk.h>
 
 G_BEGIN_DECLS
 
-#define NA_TYPE_TRAY			(na_tray_get_type ())
-#define NA_TRAY(obj)			(G_TYPE_CHECK_INSTANCE_CAST ((obj), NA_TYPE_TRAY, NaTray))
-#define NA_TRAY_CLASS(klass)		(G_TYPE_CHECK_CLASS_CAST ((klass), NA_TYPE_TRAY, NaTrayClass))
-#define NA_IS_TRAY(obj)			(G_TYPE_CHECK_INSTANCE_TYPE ((obj), NA_TYPE_TRAY))
-#define NA_IS_TRAY_CLASS(klass)		(G_TYPE_CHECK_CLASS_TYPE ((klass), NA_TYPE_TRAY))
-#define NA_TRAY_GET_CLASS(obj)		(G_TYPE_INSTANCE_GET_CLASS ((obj), NA_TYPE_TRAY, NaTrayClass))
-	
-typedef struct _NaTray		NaTray;
-typedef struct _NaTrayPrivate	NaTrayPrivate;
-typedef struct _NaTrayClass	NaTrayClass;
+#define NA_TYPE_TRAY na_tray_get_type ()
+G_DECLARE_FINAL_TYPE (NaTray, na_tray, NA, TRAY, GtkBin)
 
-struct _NaTray
-{
-  GtkBin parent_instance;
-
-  NaTrayPrivate *priv;
-};
-
-struct _NaTrayClass
-{
-  GtkBinClass parent_class;
-};
-
-GType           na_tray_get_type        (void);
-NaTray         *na_tray_new_for_screen  (GdkScreen     *screen,
-					 GtkOrientation orientation);
+NaTray         *na_tray_new_for_screen  (GtkOrientation orientation);
 void            na_tray_set_orientation	(NaTray        *tray,
 					 GtkOrientation orientation);
 GtkOrientation  na_tray_get_orientation (NaTray        *tray);
@@ -63,11 +39,10 @@ void            na_tray_set_padding     (NaTray        *tray,
 void            na_tray_set_icon_size   (NaTray        *tray,
 					 gint           icon_size);
 void            na_tray_set_colors      (NaTray        *tray,
-					 GdkColor      *fg,
-					 GdkColor      *error,
-					 GdkColor      *warning,
-					 GdkColor      *success);
-void		na_tray_force_redraw	(NaTray        *tray);
+					 GdkRGBA       *fg,
+					 GdkRGBA       *error,
+					 GdkRGBA       *warning,
+					 GdkRGBA       *success);
 
 G_END_DECLS
 

--- a/src/imports/natray/natray-1.0.vapi
+++ b/src/imports/natray/natray-1.0.vapi
@@ -4,7 +4,7 @@ namespace Na {
 		[CCode (has_construct_function = false, type = "GtkWidget*")]
 		public Tray();
 		[CCode (has_construct_function = false, type = "GtkWidget*")]
-        public Tray.for_screen(Gdk.Screen screen, Gtk.Orientation orientation);
+        public Tray.for_screen(Gtk.Orientation orientation);
 
         public void set_orientation(Gtk.Orientation orientation);
         public Gtk.Orientation get_orientation(Gtk.Orientation orientation);
@@ -12,8 +12,6 @@ namespace Na {
         public void set_padding(int padding);
         public void set_icon_size(int icon_size);
 
-        public void set_colors(Gdk.Color fg, Gdk.Color error, Gdk.Color warning, Gdk.Color success);
-
-        public void force_redraw();
+        public void set_colors(Gdk.RGBA fg, Gdk.RGBA error, Gdk.RGBA warning, Gdk.RGBA success);
 	}
 }

--- a/src/lib/animation.vala
+++ b/src/lib/animation.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/lib/manager.vala
+++ b/src/lib/manager.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/lib/shadow.vala
+++ b/src/lib/shadow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/lib/toplevel.vala
+++ b/src/lib/toplevel.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/lib/toplevel.vapi
+++ b/src/lib/toplevel.vapi
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libsession/libsession.vala
+++ b/src/libsession/libsession.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libsession/libsession.vapi
+++ b/src/libsession/libsession.vapi
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/panel/com.solus-project.budgie-panel.gschema.xml
+++ b/src/panel/com.solus-project.budgie-panel.gschema.xml
@@ -72,7 +72,7 @@
       <description>Toplevel panels</description>
     </key>
     <key type="as" name="spam-apps">
-      <default>['Spotify', 'Lollypop', 'lollypop.desktop']</default>
+      <default>['Spotify', 'Lollypop', 'lollypop.desktop', 'nm-applet', 'budgie-desktop-nm-applet.desktop']</default>
       <summary>Spam Apps</summary>
       <description>Notifications send by these apps will not be displayed in Raven.</description>
     </key>

--- a/src/panel/main.vala
+++ b/src/panel/main.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -202,6 +202,29 @@ public class PanelManager : DesktopManager
         plugins = new HashTable<string,Peas.PluginInfo?>(str_hash, str_equal);
     }
 
+    /**
+     * Attempt to reset the given path
+     */
+    public void reset_dconf_path(Settings? settings)
+    {
+        if (settings == null) {
+            return;
+        }
+        string path = settings.path;
+        settings.sync();
+        if (settings.path == null) {
+            return;
+        }
+        string argv[] = { "dconf", "reset", "-f", path};
+        message("Resetting dconf path: %s", path);
+        try {
+            Process.spawn_command_line_sync(string.joinv(" ", argv), null, null, null);
+        } catch (Error e) {
+            warning("Failed to reset dconf path %s: %s", path, e.message);
+        }
+        settings.sync();
+    }
+
     public Budgie.AppletInfo? get_applet(string key)
     {
         return null;
@@ -293,8 +316,7 @@ public class PanelManager : DesktopManager
     {
         GLib.message("Reseting budgie-panel configuration to defaults");
         Settings s = new Settings(Budgie.ROOT_SCHEMA);
-        s.reset(null);
-        s.sync();
+        this.reset_dconf_path(s);
     }
 
     /**
@@ -797,7 +819,7 @@ public class PanelManager : DesktopManager
 
 
         var psettings = new Settings.with_path(Budgie.TOPLEVEL_SCHEMA, spath);
-        psettings.reset(null);
+        this.reset_dconf_path(psettings);
     }
 
     void create_panel(string? name = null, KeyFile? new_defaults = null)

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -41,6 +41,12 @@ panel_deps = [
 
 top_vapidir = join_paths(meson.source_root(), 'vapi')
 
+# For popdown/popup methods
+extra_panel_flags = []
+if dep_gtk322.found()
+    extra_panel_flags = ['-D', 'HAVE_GTK_322']
+endif
+
 executable(
     'budgie-panel', panel_sources,
     dependencies: panel_deps,
@@ -59,6 +65,7 @@ executable(
         # Make gresource work
         '--target-glib=2.38',
         '--gresources=' + gresource,
+        extra_panel_flags,
     ],
     install: true,
 )

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -41,16 +41,7 @@ panel_deps = [
 
 top_vapidir = join_paths(meson.source_root(), 'vapi')
 
-# For popdown/popup methods
-extra_panel_flags = []
-if dep_gtk322.found()
-    extra_panel_flags = ['-D', 'HAVE_GTK_322']
-endif
-
-executable(
-    'budgie-panel', panel_sources,
-    dependencies: panel_deps,
-    vala_args: [
+budgie_panel_vala_args = [
         '--vapidir', dir_libtheme,
         '--vapidir', dir_libconfig,
         '--vapidir', dir_libplugin,
@@ -65,8 +56,17 @@ executable(
         # Make gresource work
         '--target-glib=2.38',
         '--gresources=' + gresource,
-        extra_panel_flags,
-    ],
+]
+
+# For popdown/popup methods
+if dep_gtk322.found()
+    budgie_panel_vala_args += ['-D', 'HAVE_GTK_322']
+endif
+
+executable(
+    'budgie-panel', panel_sources,
+    dependencies: panel_deps,
+    vala_args: budgie_panel_vala_args,
     install: true,
 )
 

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -998,16 +998,6 @@ public class Panel : Budgie.Toplevel
         while (Gtk.events_pending()) {
             Gtk.main_iteration();
         }
-
-        if (expanded) {
-            Idle.add(()=> {
-                if (get_window() != null) {
-                    get_window().focus(Gdk.CURRENT_TIME);
-                }
-                present();
-                return false;
-            });
-        }
     }
 
     void placement()

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -461,6 +461,9 @@ public class Panel : Budgie.Toplevel
         var iter = HashTableIter<string?,AppletInfo?>(applets);
         while (iter.next(out key, out info)) {
             Settings? app_settings = info.applet.get_applet_settings(info.uuid);
+            if (app_settings != null) {
+                app_settings.ref();
+            }
 
             // Stop it screaming when it dies
             ulong notify_id = info.get_data("notify_id");
@@ -468,12 +471,12 @@ public class Panel : Budgie.Toplevel
             SignalHandler.disconnect(info, notify_id);
             info.applet.get_parent().remove(info.applet);
 
-            // Nuke our settings for it 8
-            info.settings.reset(null);
+            // Clean up the settings
+            this.manager.reset_dconf_path(info.settings);
 
             // Nuke it's own settings
             if (app_settings != null) {
-                app_settings.reset(null);
+                this.manager.reset_dconf_path(app_settings);
             }
         }
     }
@@ -729,15 +732,18 @@ public class Panel : Budgie.Toplevel
         info.applet.get_parent().remove(info.applet);
 
         Settings? app_settings = info.applet.get_applet_settings(uuid);
+        if (app_settings != null) {
+            app_settings.ref();
+        }
 
-        info.settings.reset(null);
+        this.manager.reset_dconf_path(info.settings);
 
         /* TODO: Add refcounting and unload unused plugins. */
         applets.remove(uuid);
         applet_removed(uuid);
 
         if (app_settings != null) {
-            app_settings.reset(null);
+            this.manager.reset_dconf_path(app_settings);
         }
 
         set_applets();

--- a/src/panel/popovers.vala
+++ b/src/panel/popovers.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/panel/popovers.vala
+++ b/src/panel/popovers.vala
@@ -12,6 +12,11 @@
 namespace Budgie
 {
 
+[DBus (name="org.budgie_desktop.BudgieWM")]
+public interface BudgieWM : Object {
+    public abstract bool IsLastWindowDismissable() throws Error;
+}
+
 public class PopoverManagerImpl : PopoverManager, GLib.Object
 {
     HashTable<Gtk.Widget?,Gtk.Popover?> widgets;
@@ -22,24 +27,29 @@ public class PopoverManagerImpl : PopoverManager, GLib.Object
     bool grabbed = false;
     bool mousing = false;
 
+    BudgieWM? wm_proxy = null;
+
 
     public PopoverManagerImpl(Budgie.Panel? owner)
     {
         this.owner = owner;
         widgets = new HashTable<Gtk.Widget?,Gtk.Popover?>(direct_hash, direct_equal);
 
-        owner.focus_out_event.connect(()=>{
+        Bus.watch_name(BusType.SESSION, "org.budgie_desktop.BudgieWM", BusNameWatcherFlags.NONE,
+            has_wm, lost_wm);
+
+        owner.focus_out_event.connect((e)=>{
             if (mousing) {
                 return Gdk.EVENT_PROPAGATE;
             }
             if (visible_popover != null) {
-                #if HAVE_GTK_322
-                visible_popover.popdown();
-                #else
-                visible_popover.hide();
-                #endif
-                make_modal(visible_popover, false);
-                visible_popover = null;
+                if (wm_proxy != null && e.window != null) {
+                    if (wm_proxy.IsLastWindowDismissable()) {
+                        hide_popover();
+                    }
+                } else {
+                    hide_popover();
+                }
             }
             return Gdk.EVENT_PROPAGATE;
         });
@@ -58,18 +68,45 @@ public class PopoverManagerImpl : PopoverManager, GLib.Object
             }
             if ((e.x < alloc.x || e.x > alloc.x+alloc.width) ||
                 (e.y < alloc.y || e.y > alloc.y+alloc.height)) {
-                    #if HAVE_GTK_322
-                    visible_popover.popdown();
-                    #else
-                    visible_popover.hide();
-                    #endif
-                    make_modal(visible_popover, false);
-                    visible_popover = null;
+                hide_popover();
             }
             return Gdk.EVENT_STOP;
 
         });
         owner.add_events(Gdk.EventMask.POINTER_MOTION_MASK | Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.BUTTON_PRESS_MASK);
+    }
+
+    void lost_wm() {
+        wm_proxy = null;
+    }
+
+    void on_wm_get(GLib.Object? o, GLib.AsyncResult? res)
+    {
+        try {
+            wm_proxy = Bus.get_proxy.end(res);
+        } catch (Error e) {
+            warning("Failed to get BudgieWM proxy: %s", e.message);
+        }
+    }
+
+    void has_wm()
+    {
+        if (wm_proxy == null) {
+            Bus.get_proxy.begin<BudgieWM>(BusType.SESSION,
+                "org.budgie_desktop.BudgieWM",
+                "/org/budgie_desktop/BudgieWM", 0, null, on_wm_get);
+        }
+    }
+
+    void hide_popover()
+    {
+        #if HAVE_GTK_322
+        visible_popover.popdown();
+        #else
+        visible_popover.hide();
+        #endif
+        make_modal(visible_popover, false);
+        visible_popover = null;
     }
 
     void make_modal(Gtk.Popover? pop, bool modal = true)

--- a/src/panel/popovers.vala
+++ b/src/panel/popovers.vala
@@ -33,7 +33,11 @@ public class PopoverManagerImpl : PopoverManager, GLib.Object
                 return Gdk.EVENT_PROPAGATE;
             }
             if (visible_popover != null) {
+                #if HAVE_GTK_322
                 visible_popover.popdown();
+                #else
+                visible_popover.hide();
+                #endif
                 make_modal(visible_popover, false);
                 visible_popover = null;
             }
@@ -54,7 +58,11 @@ public class PopoverManagerImpl : PopoverManager, GLib.Object
             }
             if ((e.x < alloc.x || e.x > alloc.x+alloc.width) ||
                 (e.y < alloc.y || e.y > alloc.y+alloc.height)) {
+                    #if HAVE_GTK_322
                     visible_popover.popdown();
+                    #else
+                    visible_popover.hide();
+                    #endif
                     make_modal(visible_popover, false);
                     visible_popover = null;
             }
@@ -117,7 +125,11 @@ public class PopoverManagerImpl : PopoverManager, GLib.Object
             }
             Idle.add(()=>{
                 if (!pop.get_visible()) {
+                    #if HAVE_GTK_322
                     pop.popup();
+                    #else
+                    pop.show();
+                    #endif
                 }
                 return false;
             });

--- a/src/panel/uuid.vala
+++ b/src/panel/uuid.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/applet-info.c
+++ b/src/plugin/applet-info.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/applet-info.h
+++ b/src/plugin/applet-info.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015 Ikey Doherty
+ * Copyright © 2015-2017 Ikey Doherty
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/applet.c
+++ b/src/plugin/applet.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/applet.h
+++ b/src/plugin/applet.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015 Ikey Doherty
+ * Copyright © 2015-2017 Ikey Doherty
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/meson.build
+++ b/src/plugin/meson.build
@@ -97,6 +97,7 @@ pkgconfig.generate(
     description: 'Budgie Plugin Library',
     version: '2',
     filebase: 'budgie-1.0',
+    subdirs: 'budgie-desktop',
     libraries: ['-L${libdir}', '-lbudgie-plugin'],
     requires: [
         'gtk+-3.0 >= 3.18.0',

--- a/src/plugin/plugin.c
+++ b/src/plugin/plugin.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/plugin.h
+++ b/src/plugin/plugin.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015 Ikey Doherty
+ * Copyright © 2015-2017 Ikey Doherty
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/popover-manager.c
+++ b/src/plugin/popover-manager.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/popover-manager.h
+++ b/src/plugin/popover-manager.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015 Ikey Doherty
+ * Copyright © 2015-2017 Ikey Doherty
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/polkit/polkitdialog.vala
+++ b/src/polkit/polkitdialog.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/calendar.vala
+++ b/src/raven/calendar.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/headerwidget.vala
+++ b/src/raven/headerwidget.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/main_view.vala
+++ b/src/raven/main_view.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/mpris/MprisClient.vala
+++ b/src/raven/mpris/MprisClient.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/mpris/MprisGui.vala
+++ b/src/raven/mpris/MprisGui.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/mpris/MprisWidget.vala
+++ b/src/raven/mpris/MprisWidget.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * Copyright 2014 Josh Klar <j@iv597.com> (original Budgie work, prior to Budgie 10)
  * 
  * This program is free software; you can redistribute it and/or modify

--- a/src/raven/powerstrip.vala
+++ b/src/raven/powerstrip.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/settings_view.vala
+++ b/src/raven/settings_view.vala
@@ -829,9 +829,9 @@ public class WmSettings : Gtk.Box
     [GtkChild]
     private Gtk.Switch? switch_unredirect;
 
-    /** Button layout
+    /** Button layout */
     [GtkChild]
-    private Gtk.ComboBox? combo_layouts; */
+    private Gtk.ComboBox? combo_layouts;
 
     private GLib.Settings wm_settings;
 
@@ -840,21 +840,20 @@ public class WmSettings : Gtk.Box
         /* Force unredirect of the display, i.e. nvidia folks */
         wm_settings.bind("force-unredirect", switch_unredirect, "active", SettingsBindFlags.DEFAULT);
 
-        /* Button layout 
+        /* Button layout  */
         var model = new Gtk.ListStore(2, typeof(string), typeof(string));
         Gtk.TreeIter iter;
         model.append(out iter);
-        model.set(iter, 0, "appmenu:minimize,maximize,close", 1, _("Right (standard)"), -1);
+        model.set(iter, 0, "traditional", 1, _("Right (standard)"), -1);
         model.append(out iter);
-        model.set(iter, 0, "close,minimize,maximize:appmenu", 1, _("Left"), -1);
+        model.set(iter, 0, "left", 1, _("Left"), -1);
         combo_layouts.set_model(model);
         combo_layouts.set_id_column(0);
         var render = new Gtk.CellRendererText();
         combo_layouts.pack_start(render, true);
         combo_layouts.add_attribute(render, "text", 1);
         combo_layouts.set_id_column(0);
-        wm_settings.bind("button-layout", combo_layouts,  "active-id", SettingsBindFlags.DEFAULT);
-        */
+        wm_settings.bind("button-style", combo_layouts,  "active-id", SettingsBindFlags.DEFAULT);
     }
 }
 

--- a/src/raven/settings_view.vala
+++ b/src/raven/settings_view.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/sound.vala
+++ b/src/raven/sound.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/themes.vala
+++ b/src/raven/themes.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/ui/wm.ui
+++ b/src/raven/ui/wm.ui
@@ -52,8 +52,8 @@
             </child>
             <child>
               <object class="GtkLabel" id="label1">
+                <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="no_show_all">True</property>
                 <property name="tooltip_text" translatable="yes">Change the layout of the window buttons</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
@@ -66,8 +66,8 @@
             </child>
             <child>
               <object class="GtkComboBox" id="combo_layouts">
+                <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="no_show_all">True</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>

--- a/src/rundialog/RunDialog.vala
+++ b/src/rundialog/RunDialog.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/rundialog/RunDialog.vala
+++ b/src/rundialog/RunDialog.vala
@@ -149,7 +149,8 @@ public class RunDialog : Gtk.ApplicationWindow
 
         this.build_app_box();
 
-        set_size_request(240, -1);
+        set_size_request(420, -1);
+        set_default_size(420, -1);
         main_layout.show_all();
         set_border_width(0);
         set_resizable(false);

--- a/src/session/budgie-desktop.in
+++ b/src/session/budgie-desktop.in
@@ -4,7 +4,7 @@ BUDGIE_VERSION="@PACKAGE_VERSION@"
 
 if [ "$1" = "--version" ]; then
     echo "budgie-desktop $BUDGIE_VERSION"
-    echo "Copyright © 2014-2016 Ikey Doherty, Solus Project"
+    echo "Copyright © 2014-2017 Ikey Doherty, Solus Project"
     exit 0
 fi
 

--- a/src/theme/theme-manager.c
+++ b/src/theme/theme-manager.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2016-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/theme/theme-manager.h
+++ b/src/theme/theme-manager.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2016-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/theme/theme.c
+++ b/src/theme/theme.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/theme/theme.h
+++ b/src/theme/theme.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/theme/theme.vapi
+++ b/src/theme/theme.vapi
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/wm/background.vala
+++ b/src/wm/background.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="budgie-desktop">
 
+  <enum id="com.solus-project.budgie-wm.ButtonPosition">
+      <value nick="left" value="1" />
+      <value nick="traditional" value="2" />
+  </enum>
+
   <schema path="/com/solus-project/budgie-wm/" id="com.solus-project.budgie-wm">
     <key type="b" name="edge-tiling">
       <default>true</default>
@@ -45,6 +50,12 @@
         spacer tag can be used to insert some space between
         two adjacent buttons.
       </description>
+    </key>
+
+    <key enum="com.solus-project.budgie-wm.ButtonPosition" name="button-style">
+      <default>'traditional'</default>
+      <summary>Button layout style</summary>
+      <description>Which layout to use for window buttons</description>
     </key>
   </schema>
 

--- a/src/wm/ibus.vala
+++ b/src/wm/ibus.vala
@@ -78,7 +78,7 @@ public class IBusManager : GLib.Object
      */
     private void startup_ibus()
     {
-        string[] cmdline = {"ibus-daemon", "--xim"};
+        string[] cmdline = {"ibus-daemon", "--xim", "--panel", "disable"};
         try {
             new Subprocess.newv(cmdline, SubprocessFlags.NONE);
         } catch (Error e) {

--- a/src/wm/ibus.vala
+++ b/src/wm/ibus.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2016-2017 Ikey Doherty <ikey@solus-project.com>
  * Copyright (C) GNOME Shell Developers (Heavy inspiration, logic theft)
  *
  * This program is free software; you can redistribute it and/or modify

--- a/src/wm/ibus.vala
+++ b/src/wm/ibus.vala
@@ -78,7 +78,7 @@ public class IBusManager : GLib.Object
      */
     private void startup_ibus()
     {
-        string[] cmdline = {"ibus-daemon", "--xim", "--panel", "disable"};
+        string[] cmdline = {"ibus-daemon", "--xim"};
         try {
             new Subprocess.newv(cmdline, SubprocessFlags.NONE);
         } catch (Error e) {

--- a/src/wm/keyboard.vala
+++ b/src/wm/keyboard.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * Copyright (C) GNOME Shell Developers (Heavy inspiration, logic theft)
  * 
  * This program is free software; you can redistribute it and/or modify

--- a/src/wm/main.vala
+++ b/src/wm/main.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/meson.build
+++ b/src/wm/meson.build
@@ -17,7 +17,6 @@ budgie_wm_sources = [
 
 vapi_mutter = 'libmutter'
 dep_mutter = dependency('libmutter', version: gnome_minimum_version, required: false)
-vapi_mutter_dir = ''
 
 if not dep_mutter.found()
     dep_mutter = dependency('libmutter-0', version: gnome_minimum_version)
@@ -33,19 +32,7 @@ budgie_wm_deps = [
     dep_ibus,
 ]
 
-rpath = ''
-
-if dep_mutter.version().version_compare('>=3.21.0')
-    rpath = dep_mutter.get_pkgconfig_variable('typelibdir')
-    vapi_mutter_dir = ['--girdir', rpath]
-endif
-
-executable(
-    'budgie-wm', budgie_wm_sources,
-    dependencies: budgie_wm_deps,
-    include_directories: extra_includes,
-    install: true,
-    vala_args: [
+budgie_wm_vala_args =  [
         '--pkg', 'gio-unix-2.0',
         '--pkg', 'ibus-1.0',
         '--pkg', 'gnome-desktop-3.0',
@@ -54,8 +41,19 @@ executable(
         '--pkg', 'gsettings-desktop-schemas',
         '--vapidir', join_paths(meson.source_root(), 'vapi'),
         '--vapidir', dir_libconfig,
-        vapi_mutter_dir,
-    ],
+]
+
+if dep_mutter.version().version_compare('>=3.21.0')
+    rpath = dep_mutter.get_pkgconfig_variable('typelibdir')
+    budgie_wm_vala_args += ['--girdir', rpath]
+endif
+
+executable(
+    'budgie-wm', budgie_wm_sources,
+    dependencies: budgie_wm_deps,
+    include_directories: extra_includes,
+    install: true,
+    vala_args: budgie_wm_vala_args,
     c_args: [
         '-DGNOME_DESKTOP_USE_UNSTABLE_API',
     ],

--- a/src/wm/meson.build
+++ b/src/wm/meson.build
@@ -43,6 +43,8 @@ budgie_wm_vala_args =  [
         '--vapidir', dir_libconfig,
 ]
 
+rpath = ''
+
 if dep_mutter.version().version_compare('>=3.21.0')
     rpath = dep_mutter.get_pkgconfig_variable('typelibdir')
     budgie_wm_vala_args += ['--girdir', rpath]

--- a/src/wm/shim.vala
+++ b/src/wm/shim.vala
@@ -146,7 +146,8 @@ public class ShellShim : GLib.Object
     /* Proxy off the OSD Calls */
     private BudgieOSD? osd_proxy = null;
 
-    protected ShellShim(Budgie.BudgieWM? wm)
+    [DBus (visible = false)]
+    public ShellShim(Budgie.BudgieWM? wm)
     {
         grabs = new HashTable<uint,string>(direct_hash, direct_equal);
         watches = new HashTable<string,uint>(str_hash, str_equal);

--- a/src/wm/shim.vala
+++ b/src/wm/shim.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -1238,6 +1238,22 @@ public class BudgieWMDBUS : GLib.Object
         this.wm.restore_focused();
     }
 
+    public bool IsLastWindowDismissable()
+    {
+        unowned GLib.List<weak Meta.WindowActor>? last = Meta.Compositor.get_window_actors(
+            this.wm.get_screen()).last();
+
+        switch (last.data.get_meta_window().get_window_type()) {
+            case Meta.WindowType.POPUP_MENU:
+            case Meta.WindowType.COMBO:
+                return false;
+            default:
+                return true;
+        }
+
+        return true;
+    }
+
 } /* End BudgieWMDBUS */
 
 } /* End namespace */

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
+ * Copyright © 2015-2017 Ikey Doherty <ikey@solus-project.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -1204,11 +1204,13 @@ public class BudgieWMDBUS : GLib.Object
 
     unowned Budgie.BudgieWM? wm;
 
-    protected BudgieWMDBUS(Budgie.BudgieWM? wm)
+    [DBus (visible = false)]
+    public BudgieWMDBUS(Budgie.BudgieWM? wm)
     {
         this.wm = wm;
     }
 
+    [DBus (visible = false)]
     void on_bus_acquired(DBusConnection conn)
     {
         try {


### PR DESCRIPTION
hope i can configure to disable the 'super' key function in ubuntu budgie 17.04

i configured the shortcut with 'super' key in krita in order to change the 'alt' key.
but each time i press the short cut :'super+alt+left click' (color picker) then it will show me a launch menu , so i should press alt at first , it's annoying to press alt not super the first. 
so i wonder ubuntu budgie official to provide the function to set the super key not start the launch menu not full disable the 'super' key itself
as i asked before fossfreedom want me to create a page and ask here:

![github](https://cloud.githubusercontent.com/assets/6311930/25301937/122e719c-2765-11e7-9bbd-868e064db7d9.png)
