### PR TITLE
add style for GtkMenuBar and related objects

### DIFF
--- a/src/theme/3.18/sass/_main.scss
+++ b/src/theme/3.18/sass/_main.scss
@@ -19,6 +19,30 @@ GtkPopover GtkListBoxRow {
     opacity: 1;
 }
 
+%reset_style,
+ GtkMenuBar {
+    GtkMenuItem {
+        padding: 4px 8px;
+        border: solid transparent;
+        border-width: 0;
+        }
+
+    GtkMenuItem:hover {
+        background-color: $selected_bg_color;
+        color: $fg_color;
+        }
+
+    GtkMenuItem:insensitive {
+        color: rgba(207, 218, 231, 0.2);
+        border-color: transparent;
+        }
+
+    GtkMenuItem GtkLabel {
+        background: none;
+        color: $fg_color;
+        }
+    }
+
 // Container for both the "panel" area and the shadow. Wise to keep
 // this transparent..
 .budgie-container { background-color: transparent; }
@@ -842,3 +866,39 @@ GtkPopover GtkListBoxRow {
 
     .undershoot, .overshoot { border: none; }
 }
+
+// Budgie styled Gtk Menus
+.budgie-menubar {
+    GtkMenu {
+        margin: 4px;
+        padding: 5px;
+        border-radius: 0;
+        background-color: $panel_bg;
+        menuitem:hover {
+            background-color: $selected_bg_color;
+            color: $fg_color;
+            }
+        }
+
+    GtkArrow {
+        border:none;
+
+        &.top {
+            -gtk-icon-source:-gtk-icontheme("pan-up-symbolic");
+            border-bottom: 1px solid mix($fg_color, $raven_bg, 10%);
+        }
+
+        &.bottom {
+            -gtk-icon-source:-gtk-icontheme("pan-down-symbolic");
+            border-top: 1px solid mix($fg_color, $raven_bg, 10%);
+        }
+    }
+
+    GtkMenuItem {
+        GtkMenuAccelerator {
+            color: transparentize($fg_color, 0.65);
+        }
+
+    }
+}
+

--- a/src/theme/3.18/sass/_main.scss
+++ b/src/theme/3.18/sass/_main.scss
@@ -869,6 +869,7 @@ GtkPopover GtkListBoxRow {
 
 // Budgie styled Gtk Menus
 .budgie-menubar {
+    @extend %menu;
     GtkMenu {
         margin: 4px;
         padding: 5px;

--- a/src/theme/3.20/sass/_main.scss
+++ b/src/theme/3.20/sass/_main.scss
@@ -21,6 +21,30 @@ popover row {
     min-height: 0;
 }
 
+%reset_style,
+ menubar {
+    menuitem {
+        padding: 4px 8px;
+        border: solid transparent;
+        border-width: 0;
+        }
+
+    menuitem:hover {
+        background-color: $selected_bg_color;
+        color: $fg_color;
+        }
+
+    menuitem:disabled {
+        color: rgba(207, 218, 231, 0.2);
+        border-color: transparent;
+        }
+
+    menuitem label {
+        background: none;
+        color: $fg_color;
+        }
+    }
+
 // Container for both the "panel" area and the shadow. Wise to keep
 // this transparent..
 .budgie-container { background-color: transparent; }
@@ -893,4 +917,45 @@ button.raven-trigger {
     list row:selected .dim-label { opacity: 1; }
 
     scrolledwindow { border-top: 1px solid darken($entry_border, 5%); }
+}
+
+// Budgie styled Gtk Menus
+.budgie-menubar {
+    menu {
+        margin: 4px;
+        padding: 5px;
+        border-radius: 0;
+        background-color: $panel_bg;
+        menuitem:hover {
+            background-color: $selected_bg_color;
+            color: $fg_color;
+            }
+        }
+
+    arrow {
+        border:none;
+        min-width:16px;
+        min-height:16px;
+
+        &.top {
+            -gtk-icon-source:-gtk-icontheme("pan-up-symbolic");
+            border-bottom: 1px solid mix($fg_color, $raven_bg, 10%);
+        }
+
+        &.bottom {
+            -gtk-icon-source:-gtk-icontheme("pan-down-symbolic");
+            border-top: 1px solid mix($fg_color, $raven_bg, 10%);
+        }
+    }
+
+    menuitem {
+        accelerator {
+            color: transparentize($fg_color, 0.65);
+        }
+
+        check, radio {
+            min-height: 16px;
+            min-width: 16px;
+        }
+    }
 }

--- a/src/theme/3.20/sass/_main.scss
+++ b/src/theme/3.20/sass/_main.scss
@@ -921,6 +921,7 @@ button.raven-trigger {
 
 // Budgie styled Gtk Menus
 .budgie-menubar {
+    @extend %menu;
     menu {
         margin: 4px;
         padding: 5px;


### PR DESCRIPTION
ok - have made an attempt here to add some styling for GtkMenu based applets.  Would appreciate some thoughts and help please.

Note - the PR is just for the _main.scss changes - I havent included the full gulp compiled css files.

For such applets applying the new style-class budgie-menubar is enough to style the applet correctly when using the system theme.  Tested via my applet budgie-indicator-applet, and also the global menu applet.

The global menu applet at the moment does have an issue - the applet loses the new style class when switching between applications.  The maintainer is going to have a look.

I couldn't get the theming to work correctly without this new style class - existing Raven objects were affected.

![ubuntu xenial dev running - oracle vm virtualbox 1_015](https://cloud.githubusercontent.com/assets/996240/25728623/2b330276-3128-11e7-89df-4c055facbf5e.jpg)
