### PR TITLE
Add panel transparency controls

### DIFF
--- a/src/lib/manager.vala
+++ b/src/lib/manager.vala
@@ -25,6 +25,7 @@ public abstract class DesktopManager : GLib.Object
     public abstract uint slots_available();
     public abstract uint slots_used();
     public abstract void set_placement(string uuid, Budgie.PanelPosition position);
+    public abstract void set_transparency(string uuid, Budgie.PanelTransparency transparency);
     public abstract void set_size(string uuid, int size);
 
     public abstract void create_new_panel();

--- a/src/lib/toplevel.vala
+++ b/src/lib/toplevel.vala
@@ -39,6 +39,7 @@ public abstract class Toplevel : Gtk.Window
     public string uuid { public set ; public get; }
 
     public Budgie.PanelPosition position { public set; public get; default = Budgie.PanelPosition.BOTTOM; }
+    public Budgie.PanelTransparency transparency { public set; public get; default = Budgie.PanelTransparency.NONE; }
 
     public virtual void reset_shadow() { }
 
@@ -123,6 +124,13 @@ public enum PanelPosition {
     TOP         = 1 << 2,
     LEFT        = 1 << 3,
     RIGHT       = 1 << 4
+}
+
+[Flags]
+public enum PanelTransparency {
+    NONE        = 1 << 0,
+    DYNAMIC     = 1 << 1,
+    ALWAYS      = 1 << 2
 }
 
 [Flags]

--- a/src/lib/toplevel.vapi
+++ b/src/lib/toplevel.vapi
@@ -51,6 +51,14 @@ namespace Budgie {
 
     [CCode (cheader_filename = "BudgieToplevel.h")]
     [Flags]
+    public enum PanelTransparency {
+        NONE,
+        DYNAMIC,
+        ALWAYS
+    }
+
+    [CCode (cheader_filename = "BudgieToplevel.h")]
+    [Flags]
     public enum AppletPackType {
         START,
         END
@@ -165,6 +173,7 @@ namespace Budgie {
         public abstract uint slots_available();
         public abstract uint slots_used();
         public abstract void set_placement(string uuid, Budgie.PanelPosition position);
+        public abstract void set_transparency(string uuid, Budgie.PanelTransparency transparency);
         public abstract void set_size(string uuid, int size);
         public abstract void create_new_panel();
         public abstract void delete_panel(string uuid);

--- a/src/panel/com.solus-project.budgie-panel.gschema.xml
+++ b/src/panel/com.solus-project.budgie-panel.gschema.xml
@@ -11,6 +11,11 @@
       <value nick="center" value="2" />
       <value nick="end" value="4" />
   </enum>
+  <enum id="com.solus-project.budgie-panel.Transparency">
+      <value nick="none" value="1" />
+      <value nick="dynamic" value="2" />
+      <value nick="always" value="4" />
+  </enum>
 
   <schema id="com.solus-project.budgie-panel.panel">
     <key enum="com.solus-project.budgie-panel.Position" name="location">
@@ -23,6 +28,12 @@
       <default>39</default>
       <summary>Panel size</summary>
       <description>Height of panel if horizontal, or the width if it is vertical</description>
+    </key>
+
+    <key enum="com.solus-project.budgie-panel.Transparency" name="transparency">
+      <default>'none'</default>
+      <summary>Panel transparency</summary>
+      <description>The transparency mode of the panel</description>
     </key>
 
     <key type="b" name="enable-shadow">

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -30,6 +30,7 @@ panel_deps = [
     dep_gtk3,
     dep_peas,
     dep_libuuid,
+    dep_wnck,
     link_libconfig,
     link_libsession,
     link_libtoplevel,
@@ -63,10 +64,15 @@ if dep_gtk322.found()
     budgie_panel_vala_args += ['-D', 'HAVE_GTK_322']
 endif
 
+budgie_panel_c_args = [
+    '-DWNCK_I_KNOW_THIS_IS_UNSTABLE'
+]
+
 executable(
     'budgie-panel', panel_sources,
     dependencies: panel_deps,
     vala_args: budgie_panel_vala_args,
+    c_args: budgie_panel_c_args,
     install: true,
 )
 

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -50,6 +50,14 @@ public class MainPanel : Gtk.Box
         m = intended_size - 5;
         n = intended_size - 5;
     }
+
+    public void set_transparent(bool transparent) {
+        if (transparent) {
+            get_style_context().add_class("transparent");
+        } else {
+            get_style_context().remove_class("transparent");
+        }
+    }
 }
 
 /**
@@ -226,6 +234,29 @@ public class Panel : Budgie.Toplevel
         update_sizes();
     }
 
+    public void update_transparency(PanelTransparency transparency)
+    {
+        this.transparency = transparency;
+
+        switch (transparency) {
+            case PanelTransparency.ALWAYS:
+                set_transparent(true);
+                break;
+            case PanelTransparency.DYNAMIC:
+                manager.check_windows();
+                break;
+            default:
+                set_transparent(false);
+                break;
+        }
+
+        this.settings.set_enum(Budgie.PANEL_KEY_TRANSPARENCY, transparency);
+    }
+
+    public void set_transparent(bool transparent) {
+        (layout as MainPanel).set_transparent(transparent);
+    }
+
     public override void reset_shadow()
     {
         this.shadow.required_size = this.orig_scr.width;
@@ -334,7 +365,7 @@ public class Panel : Budgie.Toplevel
         skip_taskbar_hint = true;
         skip_pager_hint = true;
         set_decorated(false);
-    
+
         scale = get_scale_factor();
         nscale = 1.0;
 

--- a/src/raven/settings_view.vala
+++ b/src/raven/settings_view.vala
@@ -187,6 +187,10 @@ public class PanelEditor : Gtk.Box
     private ulong position_id;
 
     [GtkChild]
+    private Gtk.ComboBox? combobox_transparency;
+    private ulong transparency_id;
+
+    [GtkChild]
     private Gtk.SpinButton? spinbutton_size;
     private ulong spin_id;
 
@@ -329,6 +333,7 @@ public class PanelEditor : Gtk.Box
         combobox_panels.set_id_column(PanelColumn.UUID);
 
         position_id = combobox_position.changed.connect(on_position_changed);
+        transparency_id = combobox_transparency.changed.connect(on_transparency_changed);
         spin_id = spinbutton_size.value_changed.connect(on_size_changed);
 
         spinbutton_size.set_range(16, 200);
@@ -444,6 +449,18 @@ public class PanelEditor : Gtk.Box
         }
     }
 
+    string transparency_to_id(PanelTransparency transparency)
+    {
+        switch (transparency) {
+            case PanelTransparency.DYNAMIC:
+                return "dynamic";
+            case PanelTransparency.ALWAYS:
+                return "always";
+            default:
+                return "none";
+        }
+    }
+
     public void on_panels_changed()
     {
         button_add_panel.set_sensitive(manager.slots_available() >= 1);
@@ -518,6 +535,10 @@ public class PanelEditor : Gtk.Box
         SignalHandler.block(combobox_position, position_id);
         combobox_position.set_active_id(positition_to_id(panel.position));
         SignalHandler.unblock(combobox_position, position_id);
+
+        SignalHandler.block(combobox_transparency, transparency_id);
+        combobox_transparency.set_active_id(transparency_to_id(panel.transparency));
+        SignalHandler.unblock(combobox_transparency, transparency_id);
 
         SignalHandler.block(spinbutton_size, spin_id);
         spinbutton_size.set_value(panel.intended_size);
@@ -721,6 +742,11 @@ public class PanelEditor : Gtk.Box
             SignalHandler.block(combobox_position, position_id);
             combobox_position.set_active_id(pos);
             SignalHandler.unblock(combobox_position, position_id);
+        } else if (p.name == "transparency") {
+            var transparency = this.transparency_to_id(panel.transparency);
+            SignalHandler.block(combobox_transparency, transparency_id);
+            combobox_transparency.set_active_id(transparency);
+            SignalHandler.unblock(combobox_transparency, transparency_id);
         } else if (p.name == "intended-size") {
             SignalHandler.block(spinbutton_size, spin_id);
             spinbutton_size.set_value(panel.intended_size);
@@ -756,6 +782,25 @@ public class PanelEditor : Gtk.Box
         }
 
         manager.set_placement(current_panel.uuid, pos);
+    }
+
+    void on_transparency_changed()
+    {
+        var id = combobox_transparency.active_id;
+        PanelTransparency transparency;
+        switch (id) {
+            case "dynamic":
+                transparency = PanelTransparency.DYNAMIC;
+                break;
+            case "always":
+                transparency = PanelTransparency.ALWAYS;
+                break;
+            default:
+                transparency = PanelTransparency.NONE;
+                break;
+        }
+
+        manager.set_transparency(current_panel.uuid, transparency);
     }
 }
 

--- a/src/raven/ui/panel.ui
+++ b/src/raven/ui/panel.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkAdjustment" id="adjustment1">
@@ -230,7 +230,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">4</property>
               </packing>
             </child>
             <child>
@@ -242,7 +242,7 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">4</property>
               </packing>
             </child>
             <child>
@@ -276,7 +276,7 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">5</property>
               </packing>
             </child>
             <child>
@@ -288,7 +288,36 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label8">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="no_show_all">True</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Transparency</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBoxText" id="combobox_transparency">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="active">0</property>
+                <items>
+                  <item id="none" translatable="yes">None</item>
+                  <item id="dynamic" translatable="yes">Dynamic</item>
+                  <item id="always" translatable="yes">Always</item>
+                </items>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
           </object>

--- a/src/theme/3.18/sass/_main.scss
+++ b/src/theme/3.18/sass/_main.scss
@@ -594,6 +594,7 @@ GtkPopover GtkListBoxRow {
     background-image: none;
     box-shadow: none;
     border: none;
+    transition: all 150ms ease-in;
 
     .button {
       border-top-width: 0;
@@ -609,6 +610,18 @@ GtkPopover GtkListBoxRow {
       .bottom & {
           padding-bottom: 1px;
           border-top: 1px solid transparentize($panel_bg, 1);
+      }
+    }
+
+    &.transparent {
+      background-color: transparent;
+
+      .top & {
+        border-bottom-color: transparent;
+      }
+
+      .bottom & {
+        border-top-color: transparent;
       }
     }
 

--- a/src/theme/3.20/sass/_main.scss
+++ b/src/theme/3.20/sass/_main.scss
@@ -647,11 +647,24 @@ button.raven-trigger {
     background-image: none;
     box-shadow: none;
     border: none;
+    transition: all 150ms ease-in;
 
     button {
       border-top-width: 0;
       border-bottom-width: 0;
       border-radius: 0;
+    }
+
+    &.transparent {
+        background-color: transparent;
+
+        .top & {
+            border-bottom-color: transparent;
+        }
+
+        .bottom & {
+            border-top-color: transparent;
+        }
     }
 
     separator { background-color: transparentize($fg_color, 0.85) }


### PR DESCRIPTION
This patch adds three modes of panel transparency:
 - None (The panel is always opaque)
 - Dynamic (The panel is opaque when there is a maximized window on the workspace or if raven is open, otherwise it's transparent)
 - Always (The panel is always transparent)