### PR TITLE
About that keyboard-layout-vertical-alignment thing

### DIFF
--- a/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
+++ b/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
@@ -365,7 +365,7 @@ public class KeyboardLayoutApplet : Budgie.Applet
 
             /* Firstly we create our display label.. */
             Gtk.EventBox wrap = new Gtk.EventBox();
-            Gtk.Label displ_label = new Gtk.Label(kbinfo.layout);
+            Gtk.Label displ_label = new Gtk.Label(kbinfo.layout.up());
             wrap.add(displ_label);
             displ_label.set_halign(Gtk.Align.FILL);
             wrap.get_style_context().add_class("keyboard-label");


### PR DESCRIPTION
So I first started out by making screenshots at various font sizes to play with those in GIMP but that turned out to be totally pointless because the clock/calendar text and the keyboard-layout text _are_ perfectly aligned, namely at their respective bottoms. It's just that digits (which times and dates chiefly tend to consist of) are "uppercase" "letters" and so they're taller ofc. That's what made the whole thing look visually unbalanced. I did try to vertically center the layout name which made it _real_ ugly, so, nope. The obvious thing seemed to be to make the keyboard layout names uppercase, which is what this patch does. I'm running it atm and find it to look good both with two-letter and with three-letter keyboard layout names.

![image](https://user-images.githubusercontent.com/192860/27935548-fc1576bc-62ab-11e7-9e14-183090a92dc8.png)

![image](https://user-images.githubusercontent.com/192860/27935557-091f3ffa-62ac-11e7-9635-8022b749db81.png)