### PR TITLE
theming is broken for GTK+3.18 for discussion - not for merging

### DIFF
--- a/src/theme/3.18/_main.scss
+++ b/src/theme/3.18/_main.scss
@@ -2,10 +2,10 @@
 // this transparent..
 .budgie-container { background-color: transparent; }
 
-*:drop(active):focus,
-*:drop(active) {
-    box-shadow: inset 0 0 0 1px #F08437;
-}
+//*:drop(active):focus,
+//*:drop(active) {
+//    box-shadow: inset 0 0 0 1px #F08437;
+//}
 
 // Underscores
 %underscores {

--- a/src/theme/3.18/_widgets.scss
+++ b/src/theme/3.18/_widgets.scss
@@ -155,7 +155,7 @@
 
     @at-root %menu {
         .menu {
-            @include widget_menu('.menuitem', insensitive, '&:separator', color, '&.button');
+            @include widget_menu('.menuitem', insensitive, '&.separator', color, '&.button');
 
             .cell { color: inherit; }
         }
@@ -166,4 +166,5 @@
 
     // Calendar
     @include widget_calendar(GtkCalendar,inconsistent);
+
 }

--- a/src/theme/common/_resets.scss
+++ b/src/theme/common/_resets.scss
@@ -4,10 +4,7 @@
     border: none;
     box-shadow: none;
     text-shadow: none;
-    -gtk-icon-shadow: none;
     opacity: 1;
-    min-width: 0;
-    min-height: 0;
 }
 
 @mixin menu_reset_style($label,$insensitive) {

--- a/src/theme/common/_workspaces.scss
+++ b/src/theme/common/_workspaces.scss
@@ -11,7 +11,6 @@
 
             &:hover {
                 background: $button_bg;
-                -gtk-icon-effect: none;
             }
         }
 

--- a/src/theme/meson.build
+++ b/src/theme/meson.build
@@ -1,38 +1,11 @@
 gnome = import('gnome')
 pkgconfig = import('pkgconfig')
 
-# Compile to CSS dynamically.
-sassc = find_program('sassc')
-
-# Normal and high contrast
-theme_variants = [
-    '',
-    '_hc',
-]
-
-theme_deps = []
-theme_versions = [
-    '3.18',
-    '3.20',
-]
-
-foreach version : theme_versions
-    foreach variant : theme_variants
-        # Build the main CSS stylesheet
-        theme_deps += custom_target('theme' + variant + '_' + version + '.css',
-            input: version + '/theme' + variant + '.scss',
-            output: 'theme' + variant + '_' + version + '.css',
-            command: [sassc, '-M', '-t', 'compressed', '@INPUT@', '@OUTPUT@'],
-        )
-    endforeach
-endforeach
-
 # Compile the assets into the .so
 theme_resources = gnome.compile_resources(
     'budgie-theme-resources',
     'budgie-theme.gresource.xml',
     source_dir: meson.current_build_dir(),
-    dependencies: theme_deps,
     c_name: 'budgie_desktop_theme',
 )
 


### PR DESCRIPTION
ok,
  since the reworking of the theming there are a number of issues that break theming under GTK+3.18.

@DataDrake please can I have your thoughts?

1. After a --reset --replace the panel does not reappear.  This is because the theme cannot be loaded
2. 3.18/_main.scss: drop(active) doesnt appear to be valid.  I've commented that out for now.
3. 3.18/_widgets.scss - line 158: typo for ":separator" vs ".separator" ?
4. _resets.scss - it appears gtk-icon-shadow isnt valid for GTK+3.18
5. _workspaces.scss - similarly -gtk-icon-effect stops the theming loading

The GtkMenu icon spacing is unfortunately broken - I couldn't figure out how to fix this under the the revamped theming.  Help!

item 1 in the picture shows how the icons look currently
item 2 in the picture shows how the icons are incorrectly spaced in the Git version of budgie-desktop

![workspace 1_056](https://user-images.githubusercontent.com/996240/27993199-be38b316-649c-11e7-97c3-b4895376f9c1.jpg)

The remaining meson.build patch @ikeydoherty is aware of to allow the building of budgie desktop under 16.04