### PR TITLE
Enable TabSwitcher to go backwards as well

### DIFF
--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -15,7 +15,7 @@ namespace Budgie
 /**
  * Default width for an Switcher notification
  */
-public const int SWITCHER_SIZE= 350;
+public const int SWITCHER_SIZE = 350;
 
 /**
  * How often it is checked if the meta key is still pressed
@@ -25,7 +25,7 @@ public const int SWITCHER_MOD_EXPIRE_TIME = 50;
 /**
  * Our name on the session bus. Reserved for Budgie use
  */
-public const string SWITCHER_DBUS_NAME        = "org.budgie_desktop.TabSwitcher";
+public const string SWITCHER_DBUS_NAME = "org.budgie_desktop.TabSwitcher";
 
 /**
  * Unique object path on SWITCHER_DBUS_NAME

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -12,11 +12,11 @@
 namespace Budgie {
 
 
-public const string MUTTER_EDGE_TILING  = "edge-tiling";
-public const string MUTTER_MODAL_ATTACH = "attach-modal-dialogs";
+public const string MUTTER_EDGE_TILING   = "edge-tiling";
+public const string MUTTER_MODAL_ATTACH  = "attach-modal-dialogs";
 public const string MUTTER_BUTTON_LAYOUT = "button-layout";
-public const string WM_FORCE_UNREDIRECT = "force-unredirect";
-public const string WM_SCHEMA           = "com.solus-project.budgie-wm";
+public const string WM_FORCE_UNREDIRECT  = "force-unredirect";
+public const string WM_SCHEMA            = "com.solus-project.budgie-wm";
 
 public const bool CLUTTER_EVENT_PROPAGATE = false;
 public const bool CLUTTER_EVENT_STOP      = true;
@@ -1172,7 +1172,7 @@ public class BudgieWM : Meta.Plugin
         if (cur_tabs == null) {
             return;
         }
-        switch_switcher();
+        switch_switcher(true); /* true as in "yes, backward" */
     }
 
     public void switch_windows(Meta.Display display, Meta.Screen screen,
@@ -1208,16 +1208,24 @@ public class BudgieWM : Meta.Plugin
         switch_switcher();
     }
 
-    public void switch_switcher()
+    public void switch_switcher(bool backward = false)
     {
         /* Pass each window over to tabswitcher */
         foreach (var child in cur_tabs) {
             uint32 xid = (uint32)child.get_xwindow();
             switcher_proxy.PassItem(xid, child.get_user_time());
         }
-        cur_index++;
-        if (cur_index > cur_tabs.length()-1) {
-            cur_index = 0;
+        /* Either choose previous or choose next window */
+        if (backward) {
+            cur_index--;
+            if (cur_index < 0) {
+                cur_index = (int)cur_tabs.length() - 1;
+            }
+        } else {
+            cur_index++;
+            if (cur_index > cur_tabs.length() - 1) {
+                cur_index = 0;
+            }
         }
         /* Get the new selected window over to TabSwitcher */
         var win = cur_tabs.nth_data(cur_index);


### PR DESCRIPTION
Hi Ikey, so the backward switching with whatever is set in `gnome-control-center` finally works now. Is it okay like this?