### PR TITLE
Change Places indicator icon

### DIFF
--- a/src/applets/places-indicator/PlacesIndicator.plugin.in
+++ b/src/applets/places-indicator/PlacesIndicator.plugin.in
@@ -5,4 +5,4 @@ _Description=Places
 Authors=Budgie Desktop Developers
 Copyright=Copyright © 2016-2017 Budgie Desktop Developers
 Website=https://solus-project.com
-Icon=drive-harddisk-symbolic
+Icon=folder-symbolic

--- a/src/applets/places-indicator/PlacesIndicator.vala
+++ b/src/applets/places-indicator/PlacesIndicator.vala
@@ -80,7 +80,7 @@ public class PlacesIndicatorApplet : Budgie.Applet
         ebox = new Gtk.EventBox();
         Gtk.Box layout = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
         ebox.add(layout);
-        image = new Gtk.Image.from_icon_name("drive-harddisk-symbolic", Gtk.IconSize.MENU);
+        image = new Gtk.Image.from_icon_name("folder-symbolic", Gtk.IconSize.MENU);
         layout.pack_start(image, true, true, 3);
         label = new Gtk.Label(_("Places"));
         label.halign = Gtk.Align.START;


### PR DESCRIPTION
drive-harddisk-symbolic -> folder-symbolic

Saw that this was assigned to @cybre in the issue, but I went ahead and made the change for him. Hope this isn't over-stepping.

Addreses #690 