### PR TITLE
build: List static libraries before shared ones

### DIFF
--- a/src/raven/meson.build
+++ b/src/raven/meson.build
@@ -26,12 +26,14 @@ libraven_sources = [
 ]
 
 libraven_deps = [
+    # XXX: Keep this order the same to work around
+    # https://github.com/mesonbuild/meson/issues/2096
+    link_libtoplevel,
     libplugin_vapi,
     dep_gtk3,
     dep_peas,
     link_libconfig,
     link_libplugin,
-    link_libtoplevel,
     link_libtheme,
     gvc.get_variable('link_libgvc'),
 ]


### PR DESCRIPTION
Workaround for: https://github.com/mesonbuild/meson/issues/2096

Affects Meson v0.41.{0,1,2}

Closes https://github.com/budgie-desktop/budgie-desktop/issues/1044