### PR TITLE
applets/places-indicator: Show bookmark names

### DIFF
--- a/src/applets/places-indicator/PlaceItem.vala
+++ b/src/applets/places-indicator/PlaceItem.vala
@@ -11,12 +11,14 @@
 
 public class PlaceItem : ListItem
 {
-    public PlaceItem(GLib.File file, string class)
+    public PlaceItem(GLib.File file, string class, string? bookmark_name)
     {
         item_class = class;
 
         string name = "";
-        if (file.get_basename() == "/" && file.get_uri() != "file:///") {
+        if (bookmark_name != null) {
+            name = bookmark_name;
+        } else if (file.get_basename() == "/" && file.get_uri() != "file:///") {
             name = file.get_uri().split("://")[1];
             if (name.has_suffix("/")) {
                 name = name[0:name.length - 1];

--- a/src/applets/places-indicator/PlacesIndicatorWindow.vala
+++ b/src/applets/places-indicator/PlacesIndicatorWindow.vala
@@ -456,7 +456,14 @@ public class PlacesIndicatorWindow : Budgie.Popover {
      */
     private void add_place(string path, string class)
     {
-        string place = path.split(" ")[0];
+
+        string[] arr = path.split(" ");
+        string place = arr[0];
+        string place_name = "";
+
+        for (int i = 1; i < arr.length; i++) {
+            place_name += arr[i] + " ";
+        }
         string unescaped_path = GLib.Uri.unescape_string(place);
 
         if (places_list.contains(unescaped_path)) {
@@ -465,7 +472,12 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 
         GLib.File file = GLib.File.new_for_uri(unescaped_path);
 
-        PlaceItem place_item = new PlaceItem(file, "place");
+        PlaceItem place_item;
+        if (class == "bookmark" && place_name != "") {
+            place_item = new PlaceItem(file, "place", place_name);
+        } else {
+            place_item = new PlaceItem(file, "place", null);
+        }
         place_item.close_popover.connect(() => { this.hide(); });
         places_list.add(unescaped_path);
         places_section.add_item(place_item);


### PR DESCRIPTION
Before it just showed the folder name (the two on the bottom)
![places-indicator-before](https://user-images.githubusercontent.com/10762082/29488946-726b7f7e-8515-11e7-8ec3-c203e2ade338.png)
Fixed to show the bookmark name instead:
![places-indicator-after](https://user-images.githubusercontent.com/10762082/29488945-726b481a-8515-11e7-9fb1-37478f2cc5fe.png)

