### PR TITLE
set settings window title to match the .desktop name #1146

### DIFF
--- a/src/panel/settings/settings_main.vala
+++ b/src/panel/settings/settings_main.vala
@@ -48,7 +48,7 @@ public class SettingsWindow : Gtk.Window {
         add(layout);
 
         /* Have to override wmclass for pinning support */
-        set_title(_("Budgie Settings"));
+        set_title(_("Budgie Desktop Settings"));
         set_wmclass("budgie-desktop-settings", "budgie-desktop-settings");
         set_icon_name("preferences-desktop");
 


### PR DESCRIPTION
I suppose there is two ways to resolve this - either set the window title to be the same as the .desktop name ...

or visa versa.

The PR chooses the former.