### PR TITLE
panel: Read date format from gsettings

### DIFF
--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -303,7 +303,13 @@ public class ClockApplet : Budgie.Applet
         }
 
         settings = new Settings("com.solus-project.budgie-panel");
-        string ftime = (string)settings.get_string("date-format");
+
+        string ftime;
+        if (this.orient == Gtk.Orientation.HORIZONTAL) {
+            ftime = settings.get_string("date-format");
+        } else {
+            ftime = settings.get_string("date-format-vertical");
+        }
 
         // Prevent unnecessary redraws
         var old = date_label.get_label();

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -301,12 +301,9 @@ public class ClockApplet : Budgie.Applet
         if (!check_date.get_active()) {
             return;
         }
-        string ftime;
-        if (this.orient == Gtk.Orientation.HORIZONTAL) {
-            ftime = "%x";
-        } else {
-            ftime = "<small>%b %d</small>";
-        }
+
+        settings = new Settings("com.solus-project.budgie-panel");
+        string ftime = (string)settings.get_string("date-format");
 
         // Prevent unnecessary redraws
         var old = date_label.get_label();

--- a/src/panel/com.solus-project.budgie-panel.gschema.xml
+++ b/src/panel/com.solus-project.budgie-panel.gschema.xml
@@ -140,5 +140,10 @@
       <summary>Name of the default desktop layout</summary>
       <description>The name of the default layout used when resetting the panel</description>
     </key>
+    <key type="s" name="date-format">
+      <default>'%x'</default>
+      <summary>Date format of the clock applet</summary>
+      <description>Set the date format. Uses the same format as date command.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/panel/com.solus-project.budgie-panel.gschema.xml
+++ b/src/panel/com.solus-project.budgie-panel.gschema.xml
@@ -145,5 +145,10 @@
       <summary>Date format of the clock applet</summary>
       <description>Set the date format. Uses the same format as date command.</description>
     </key>
+    <key type="s" name="date-format-vertical">
+      <default><![CDATA['<small>%b %d</small>']]></default>
+      <summary>Date format of the clock applet</summary>
+      <description>Set the date format when using vertical panel. Uses the same format as date command.</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
The clock applet read the date format from gsettings instead of use the hardcoded
value. The default format is still '%x'. This closes #1039.

I've placed the format setting at: `/com/solus-project/budgie-panel/date-format`. Let me know if that's not the best path.