### PR TITLE
Check for gtkdocize if we have documentation enabled.

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,3 +1,5 @@
+find_program('gtkdocize', required: true)
+
 # Handles gtkdoc installation
 gnome = import('gnome')
 


### PR DESCRIPTION
Ensures catching missing builddep during configuration rather than install.