### PR TITLE
Initialise system tray via idle #1249

### DIFF
--- a/src/applets/tray/TrayApplet.vala
+++ b/src/applets/tray/TrayApplet.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2017 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -39,22 +39,25 @@ public class TrayApplet : Budgie.Applet
         box.vexpand = false;
         vexpand = false;
 
-        map.connect_after(()=> {
-            maybe_integrate_tray();
+        Idle.add(()=> {
+            map.connect_after(()=> {
+                maybe_integrate_tray();
+            });
+
+
+            show_all();
+            panel_size_changed.connect((p,i,s)=> {
+                this.icon_size = s;
+                if (tray != null) {
+                    tray.set_icon_size(icon_size);
+                    queue_resize();
+                    tray.queue_resize();
+                }
+            });
+
+            size_allocate.connect(on_size_allocate);
+            return false;
         });
-
-
-        show_all();
-        panel_size_changed.connect((p,i,s)=> {
-            this.icon_size = s;
-            if (tray != null) {
-                tray.set_icon_size(icon_size);
-                queue_resize();
-                tray.queue_resize();
-            }
-        });
-
-        size_allocate.connect(on_size_allocate);
     }
 
     public override void panel_position_changed(Budgie.PanelPosition position)


### PR DESCRIPTION
 Initialise the startup of the system tray via GLib idle.
 This allows the system tray startup fully stopping black background
 and icon positioning issues.

I have had the UB team running with this patch for a couple of weeks.  We haven't managed to reproduce either the black-background issue or the mixed up icons when running with the patch.

No obvious regressions have been observed as well.

Think it is worth trying this with a much wider audience if possible.