### PR TITLE
applets/icon-tasklist: Rely on GtkImage due to icon scaling being bork

### DIFF
--- a/src/applets/icon-tasklist/Icon.vala
+++ b/src/applets/icon-tasklist/Icon.vala
@@ -11,10 +11,8 @@
 
 const int MAX_CYCLES = 12;
 
-public class Icon : Gtk.DrawingArea
+public class Icon : Gtk.Image
 {
-    public Gdk.Pixbuf? pixbuf = null;
-    private int size = 24;
     private int widget_width = 36;
     private int widget_height = 30;
     private Budgie.PanelPosition panel_position = Budgie.PanelPosition.BOTTOM;
@@ -63,26 +61,6 @@ public class Icon : Gtk.DrawingArea
 
     public Icon() {}
 
-    public Icon.from_gicon(GLib.Icon icon, int pixel_size) {
-        set_from_gicon(icon, pixel_size);
-    }
-
-    public Icon.from_pixbuf(Gdk.Pixbuf pb, int pixel_size) {
-        set_from_pixbuf(pb, pixel_size);
-    }
-
-    public Icon.from_icon_name(string icon_name, int pixel_size) {
-        set_from_icon_name(icon_name, pixel_size);
-    }
-
-    public void set_widget_width(int width) {
-        this.widget_width = width;
-    }
-
-    public void set_widget_height(int height) {
-        this.widget_height = height;
-    }
-
     public override void size_allocate(Gtk.Allocation allocation) {
         this.queue_resize();
         Gtk.Allocation alloc;
@@ -102,58 +80,6 @@ public class Icon : Gtk.DrawingArea
         Gtk.Allocation alloc;
         this.get_parent().get_allocation(out alloc);
         min = nat = this.widget_height = alloc.height;
-    }
-
-    public void set_from_gicon(GLib.Icon icon, int pixel_size)
-    {
-        this.size = pixel_size;
-        Gtk.IconTheme icon_theme = Gtk.IconTheme.get_default();
-        Gtk.IconInfo info = icon_theme.lookup_by_gicon(icon, this.size, Gtk.IconLookupFlags.FORCE_REGULAR);
-        try {
-            this.pixbuf = info.load_icon();
-        } catch (GLib.Error e) {
-            warning(e.message);
-        }
-        GLib.Idle.add(() => {
-            this.queue_resize();
-            this.queue_draw();
-            return false;
-        });
-    }
-
-    public void set_from_pixbuf(Gdk.Pixbuf pb, int pixel_size) {
-        this.size = pixel_size;
-        this.pixbuf = pb;
-        GLib.Idle.add(() => {
-            this.queue_resize();
-            this.queue_draw();
-            return false;
-        });
-    }
-
-    public void set_from_icon_name(string icon_name, int pixel_size)
-    {
-        this.size = pixel_size;
-        Gtk.IconTheme icon_theme = Gtk.IconTheme.get_default();
-        try {
-            this.pixbuf = icon_theme.load_icon(icon_name, this.size, Gtk.IconLookupFlags.FORCE_REGULAR);
-        } catch (GLib.Error e) {
-            warning(e.message);
-        }
-        GLib.Idle.add(() => {
-            this.queue_resize();
-            this.queue_draw();
-            return false;
-        });
-    }
-
-    public void set_size(int pixel_size) {
-        this.size = pixel_size;
-        GLib.Idle.add(() => {
-            this.queue_resize();
-            this.queue_draw();
-            return false;
-        });
     }
 
     public void animate_attention(Budgie.PanelPosition? position)
@@ -270,9 +196,9 @@ public class Icon : Gtk.DrawingArea
         double old_value;
 
         if (position == Budgie.PanelPosition.TOP || position == Budgie.PanelPosition.BOTTOM) {
-            old_value = (double)((this.widget_height-this.size)/2);
+            old_value = (double)((this.widget_height-this.pixel_size)/2);
         } else {
-            old_value = (double)((this.widget_width-this.size)/2);
+            old_value = (double)((this.widget_width-this.pixel_size)/2);
         }
 
         BudgieTaskList.Animation launch_animation = new BudgieTaskList.Animation();
@@ -294,14 +220,19 @@ public class Icon : Gtk.DrawingArea
 
     public override bool draw(Cairo.Context cr)
     {
-        if (pixbuf == null) {
-            return false;
-        }
+        Gtk.Allocation alloc;
+        get_allocation(out alloc);
 
-        int x = (this.widget_width / 2) - (this.size / 2);
-        int y = (this.widget_height / 2) - (this.size / 2);
+        /* Have base implementation render first */
+        var buffer = new Cairo.ImageSurface(Cairo.Format.ARGB32, alloc.width, alloc.height);
+        var cr2 = new Cairo.Context(buffer);
+        base.draw(cr2);
 
+        /* Always start from 0 because the surface is correctly aligned */
+        int x = 0;
+        int y = 0;
 
+        /* Offset the drawing */
         if (this.panel_position == Budgie.PanelPosition.LEFT) {
             x += (int)bounce_amount;
             y += (int)attention_amount;
@@ -316,7 +247,8 @@ public class Icon : Gtk.DrawingArea
             x += (int)attention_amount;
         }
 
-        Gdk.cairo_set_source_pixbuf(cr, pixbuf, x, y);
+        /* Render with our own offsets now */
+        cr.set_source_surface(buffer, x, y);
         cr.paint();
 
         return true;

--- a/src/applets/icon-tasklist/IconButton.vala
+++ b/src/applets/icon-tasklist/IconButton.vala
@@ -108,6 +108,7 @@ public class IconButton : Gtk.ToggleButton
         this.add_events(Gdk.EventMask.SCROLL_MASK);
         this.set_draggable(!this.desktop_helper.lock_icons);
 
+        /*
         drag_begin.connect((context) => {
             unowned Gdk.Pixbuf? pixbuf_icon = this.icon.pixbuf;
 
@@ -126,7 +127,7 @@ public class IconButton : Gtk.ToggleButton
                 id = this.window.get_name();
             }
             selection_data.set(selection_data.get_target(), 8, (uchar[])id.to_utf8());
-        });
+        });*/
 
         var st = get_style_context();
         st.remove_class(Gtk.STYLE_CLASS_BUTTON);
@@ -281,12 +282,13 @@ public class IconButton : Gtk.ToggleButton
         }
 
         if (app_icon != null) {
-            icon.set_from_gicon(app_icon, this.desktop_helper.icon_size);
+            icon.set_from_gicon(app_icon, Gtk.IconSize.INVALID);
         } else if (pixbuf_icon != null) {
-            icon.set_from_pixbuf(pixbuf_icon, this.desktop_helper.icon_size);
+            icon.set_from_pixbuf(pixbuf_icon);
         } else {
-            icon.set_from_icon_name("image-missing", this.desktop_helper.icon_size);
+            icon.set_from_icon_name("image-missing", Gtk.IconSize.INVALID);
         }
+        icon.pixel_size = this.desktop_helper.icon_size;
     }
 
     public void update()


### PR DESCRIPTION
GtkImage relys on private GtkIconHelper and GtkScaling which aren't part
of the public API, so GtkIconTheme will continously fail for us even when
using the `_for_scale` APIs, as the GdkPixbufs will never scale correctly.
Instead, bite the bullet and extend GtkImage with custom rendering on top
of a cairo surface much like we do in Raven.

This fixes #1422

Signed-off-by: Ikey Doherty <ikey@solus-project.com>