### PR TITLE
Added checkbutton to Keyboard Layout applet to quickly switch between per-wi…

### DIFF
--- a/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
+++ b/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
@@ -280,7 +280,24 @@ public class KeyboardLayoutApplet : Budgie.Applet {
 		listbox.set_can_focus(false);
 		listbox.set_selection_mode(Gtk.SelectionMode.NONE);
 		listbox.get_style_context().add_class("content-box");
-		popover.add(listbox);
+
+		/* (per window CheckButton) */
+		GLib.Settings perwindowsettings = new GLib.Settings("org.gnome.desktop.input-sources");
+		Gtk.Grid popovergrid = new Gtk.Grid();
+		popovergrid.attach(listbox, 0, 0, 1, 1);
+		Gtk.Grid perwindowgrid = new Gtk.Grid();
+		/* Let's add a little space above, to visually separate */
+		perwindowgrid.set_margin_top(7);
+		Gtk.CheckButton perwindowbutton = new Gtk.CheckButton.with_label(_("Change per-window"));
+		perwindowsettings.bind(
+			"per-window", perwindowbutton, "active", SettingsBindFlags.GET|SettingsBindFlags.SET
+		);
+		perwindowbutton.set_relief(Gtk.ReliefStyle.NONE);
+		perwindowbutton.set_can_focus(false);
+		perwindowgrid.attach(perwindowbutton, 0, 0, 1, 1);
+		popovergrid.attach(perwindowgrid, 0, 1, 1, 1);
+
+		popover.add(popovergrid);
 		popover.get_child().show_all();
 
 		/* Settings/init */


### PR DESCRIPTION
…ndow mode and one-for-all input source.

## Description
In the past, gsettings' org.gnome.desktop.input-sources _per-window_ - option was broken, which lead to a separate applet in the Ubuntu Budgie extras repository to automatically switch input sources per window (/application). Currently however the option was fixed, and the applet is no longer needed. To improve discover-ability of the option, and to be able to quickly toggle, the existing Keyboard Layout applet seems to be the perfect place.

![afbeelding](https://user-images.githubusercontent.com/8932980/133657394-e4fca085-5722-4500-8842-96015c9043b6.png)



### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
 [ x ] Built budgie-desktop and verified that the patch worked (if needed)
